### PR TITLE
build: initial web common module

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'fulflix'
+
+include("web-common")

--- a/web-common/build.gradle.kts
+++ b/web-common/build.gradle.kts
@@ -1,0 +1,11 @@
+val jar: Jar by tasks
+jar.enabled = true
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api("org.springframework.boot:spring-boot-starter-web")
+    api("org.springframework.boot:spring-boot-starter-data-jpa")
+}

--- a/web-common/src/main/java/io/fulflix/common/WebCommonConfig.java
+++ b/web-common/src/main/java/io/fulflix/common/WebCommonConfig.java
@@ -1,0 +1,8 @@
+package io.fulflix.common;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+@EnableAutoConfiguration
+public abstract class WebCommonConfig {
+
+}

--- a/web-common/src/main/java/io/fulflix/common/context/UserContextConfig.java
+++ b/web-common/src/main/java/io/fulflix/common/context/UserContextConfig.java
@@ -1,0 +1,18 @@
+package io.fulflix.common.context;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class UserContextConfig implements WebMvcConfigurer {
+
+    public static final String ALL_REQUEST = "/**";
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new UserContextHolderInterceptor())
+            .addPathPatterns(ALL_REQUEST);
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/context/UserContextHolder.java
+++ b/web-common/src/main/java/io/fulflix/common/context/UserContextHolder.java
@@ -1,0 +1,19 @@
+package io.fulflix.common.context;
+
+public class UserContextHolder {
+
+    private static final ThreadLocal<String> currentUser = new ThreadLocal<>();
+
+    public static void setCurrentUser(String userId) {
+        currentUser.set(userId);
+    }
+
+    public static String getCurrentUser() {
+        return currentUser.get();
+    }
+
+    public static void clear() {
+        currentUser.remove();
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/context/UserContextHolderInterceptor.java
+++ b/web-common/src/main/java/io/fulflix/common/context/UserContextHolderInterceptor.java
@@ -1,0 +1,36 @@
+package io.fulflix.common.context;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class UserContextHolderInterceptor implements HandlerInterceptor {
+
+    public static final String X_USER_ID = "X-User-Id";
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) {
+        String userId = getUserIdFromHeader(request);
+        UserContextHolder.setCurrentUser(userId);
+        return true;
+    }
+
+    private String getUserIdFromHeader(HttpServletRequest request) {
+        return request.getHeader(X_USER_ID);
+    }
+
+    @Override
+    public void afterCompletion(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler,
+        Exception ex
+    ) {
+        UserContextHolder.clear();
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/context/annotation/CurrentUser.java
+++ b/web-common/src/main/java/io/fulflix/common/context/annotation/CurrentUser.java
@@ -1,0 +1,12 @@
+package io.fulflix.common.context.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+
+}

--- a/web-common/src/main/java/io/fulflix/common/context/annotation/CurrentUserArgumentResolver.java
+++ b/web-common/src/main/java/io/fulflix/common/context/annotation/CurrentUserArgumentResolver.java
@@ -1,0 +1,27 @@
+package io.fulflix.common.context.annotation;
+
+import io.fulflix.common.context.UserContextHolder;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) {
+        return UserContextHolder.getCurrentUser();
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/context/annotation/CurrentUserResolverConfig.java
+++ b/web-common/src/main/java/io/fulflix/common/context/annotation/CurrentUserResolverConfig.java
@@ -1,0 +1,16 @@
+package io.fulflix.common.context.annotation;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CurrentUserResolverConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new CurrentUserArgumentResolver());
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/jpa/JpaConfig.java
+++ b/web-common/src/main/java/io/fulflix/common/jpa/JpaConfig.java
@@ -1,0 +1,10 @@
+package io.fulflix.common.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+public class JpaConfig {
+
+}

--- a/web-common/src/main/java/io/fulflix/common/jpa/audit/Auditable.java
+++ b/web-common/src/main/java/io/fulflix/common/jpa/audit/Auditable.java
@@ -1,0 +1,22 @@
+package io.fulflix.common.jpa.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+
+@Getter
+@MappedSuperclass
+public abstract class Auditable extends CommonAuditFields {
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    protected Long createdBy;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/web-common/src/main/java/io/fulflix/common/jpa/audit/CommonAuditFields.java
+++ b/web-common/src/main/java/io/fulflix/common/jpa/audit/CommonAuditFields.java
@@ -1,0 +1,30 @@
+package io.fulflix.common.jpa.audit;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CommonAuditFields {
+
+    public static final String DEFAULT_CONDITION = "is_deleted = false";
+
+    @LastModifiedBy
+    private Long updatedBy;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private boolean isDeleted = false;
+
+    public void delete() {
+        isDeleted = true;
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/jpa/audit/UserAuditorAwareConfig.java
+++ b/web-common/src/main/java/io/fulflix/common/jpa/audit/UserAuditorAwareConfig.java
@@ -1,0 +1,18 @@
+package io.fulflix.common.jpa.audit;
+
+import io.fulflix.common.context.UserContextHolder;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+@Configuration
+public class UserAuditorAwareConfig {
+
+    @Bean
+    public AuditorAware<Long> getCurrentAuditor() {
+        return () -> Optional.of(UserContextHolder.getCurrentUser())
+            .map(Long.class::cast);
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/web/utils/PropertiesCombineUtils.java
+++ b/web-common/src/main/java/io/fulflix/common/web/utils/PropertiesCombineUtils.java
@@ -1,0 +1,19 @@
+package io.fulflix.common.web.utils;
+
+public class PropertiesCombineUtils {
+
+    public static final String CONFIGURATION_PROPERTIES_NAME = "spring.config.name";
+    public static final String APP_COMMON_PROPERTY = "application";
+    public static final String BASE_PACKAGE = "io.fulflix";
+
+    private static final String DELIMITER = ", ";
+
+    public static String combinedApplicationProperties(String properties) {
+        return combine(APP_COMMON_PROPERTY, properties);
+    }
+
+    private static String combine(String... properties) {
+        return String.join(DELIMITER, properties);
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/web/utils/UriComponentUtils.java
+++ b/web-common/src/main/java/io/fulflix/common/web/utils/UriComponentUtils.java
@@ -1,0 +1,14 @@
+package io.fulflix.common.web.utils;
+
+import java.net.URI;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class UriComponentUtils {
+
+    public static <T> URI generateResourceUri(final String baseUri, T path) {
+        return UriComponentsBuilder.fromUriString(baseUri)
+            .buildAndExpand(path)
+            .toUri();
+    }
+
+}

--- a/web-common/src/main/resources/application.yml
+++ b/web-common/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles.active: test
+  config:
+    import:
+      - classpath:properties/datasource.yml
+      - classpath:properties/jpa.yml

--- a/web-common/src/main/resources/properties/datasource.yml
+++ b/web-common/src/main/resources/properties/datasource.yml
@@ -1,0 +1,8 @@
+spring:
+  config.activate.on-profile: test
+  datasource:
+    hikari.jdbc-url: jdbc:h2:mem:test_db;MODE=MySQL;
+    username: sa
+    password:
+
+---

--- a/web-common/src/main/resources/properties/jpa.yml
+++ b/web-common/src/main/resources/properties/jpa.yml
@@ -1,0 +1,14 @@
+spring:
+  jpa:
+    open-in-view: false
+---
+spring:
+  config.activate.on-profile: test
+  jpa:
+    database: mysql
+    hibernate.ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        highlight_sql: true


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
MSA 환경에서 JPA의 audit 사용을 위해 필요한 환경 및 필드를 구성 합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 spring-web, spring-jpa 의존성을 가지는 공통 모듈 구성
- 📌 jpa audit 적용 대상 필드 구성
- 📌 security-context-holder를 대체할 ThreadLocal기반의 CustomContextHolder 구현
- 📌 API GW로 부터 라우팅된 요청 헤더의 현재 요청 사용자 정보를 저장하기 위한 CustomContextInterceptor 구현
- 📌 현재 사용자 정보가 저장된 UserContextHolder로부터 JPA Audinting 대상 필드의 값 참조를 위한 JPA AuditingAware 설정

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
> -

## 💬 리뷰 요구사항

> User를 제외한 모든 Entity에 공통으로 필요한 auditing 항목을 Auditable class에 구현하였습니다. Auditable class를 상속 받은 Entity는 insert/update/soft-delete event 발생 시, 추적 및 감사를 위해 필요한 필드들이 자동으로 적용됩니다.

## 📚 참고 자료

> -

---
