### PR TITLE
config: yaml importer configurations

### DIFF
--- a/user-app/src/main/java/io/fulflix/user/UserApp.java
+++ b/user-app/src/main/java/io/fulflix/user/UserApp.java
@@ -1,22 +1,24 @@
 package io.fulflix.user;
 
 import static io.fulflix.common.web.utils.PropertiesCombineUtils.BASE_PACKAGE;
-import static io.fulflix.common.web.utils.PropertiesCombineUtils.CONFIGURATION_PROPERTIES_NAME;
-import static io.fulflix.common.web.utils.PropertiesCombineUtils.combinedApplicationProperties;
 
+import io.fulflix.common.web.config.YamlPropertySourceFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 
+@PropertySources({
+    @PropertySource(
+        name = "user-app-properties",
+        value = "classpath:application-user.yml",
+        factory = YamlPropertySourceFactory.class
+    )
+})
 @SpringBootApplication(scanBasePackages = BASE_PACKAGE)
 public class UserApp {
 
-    private static final String USER_APP_PROPERTY = "application-user";
-
     public static void main(String[] args) {
-        System.setProperty(
-            CONFIGURATION_PROPERTIES_NAME,
-            combinedApplicationProperties(USER_APP_PROPERTY)
-        );
         SpringApplication.run(UserApp.class, args);
     }
 

--- a/web-common/src/main/java/io/fulflix/common/web/config/YamlPropertySourceFactory.java
+++ b/web-common/src/main/java/io/fulflix/common/web/config/YamlPropertySourceFactory.java
@@ -1,0 +1,32 @@
+package io.fulflix.common.web.config;
+
+import jakarta.annotation.Nullable;
+import java.io.IOException;
+import java.util.Properties;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+public class YamlPropertySourceFactory implements PropertySourceFactory {
+
+    public static final String YAML_PROPERTIES_LOAD_ERROR_FORMAT = "Could not load YAML properties from :[%s]";
+
+    @Override
+    public PropertySource<?> createPropertySource(
+        @Nullable String name,
+        EncodedResource resource
+    ) throws IOException {
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(resource.getResource());
+        Properties properties = factory.getObject();
+        String filename = resource.getResource().getFilename();
+
+        if (properties == null) {
+            throw new IOException(YAML_PROPERTIES_LOAD_ERROR_FORMAT.formatted(filename));
+        }
+        return new PropertiesPropertySource(filename, properties);
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
application 구동을 위한 환경 설정(yml, properties)주입 시, spring의 @PropertySources는 .properties 확장자만 지원합니다.

가독성과 유지 보수성을 위해 yml 기반으로 작성된 application 환경 설정을 주입을 위해 기존 JVM 종속적인 방법을 사용하여 주입하였지만, Spring에서 제공하는 PropertySourceFactory 기반의 CustomPropertiesFactory를 구현 하여 기존 yml 주입을 위해 구현된 JVM 종속적인 방법을 PropertySourceFactory기반으로 변경 합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 yml 기반의 application properties 주입을 위한 CustomPropertiesFactory 구현
- 📌 user-app 모듈에 JVM 종속적인 yml 주입 방법을 CustomPropertiesFactory로 변경 

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> auth-app, user-app에 작성된 TC가 정상적으로 동작함을 확인하였습니다.

## 💬 리뷰 요구사항

> app-common 의존성이 추가되는 각 service-module은 entry-point에 아래와 같은 방법으로 app-common에 작성된 yml 기반의 공통 환경 설정을 주입할 수 있습니다.

```java
@PropertySources({
    @PropertySource(
        name = "{service}-app-properties",
        value = "classpath:application-{service}.yml",
        factory = YamlPropertySourceFactory.class
    )
})
```


## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!
[baeldung : spring-yaml-propertysource](https://www.baeldung.com/spring-yaml-propertysource)
[Spring 6.1.12 docs : PropertySourceFactory](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/support/PropertySourceFactory.html)
[baeldung : properties with spring](https://www.baeldung.com/properties-with-spring)
---
