### PR TITLE
config: add jpa test base configurations

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -19,6 +19,8 @@ artifacts {
 val webCommonModule = ":web-common"
 
 dependencies {
-    api("org.springframework.boot:spring-boot-starter-data-jpa")
     api(project(webCommonModule))
+    api("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    testImplementation(project(path = webCommonModule, configuration = "archives"))
 }

--- a/app-common/src/test/java/io/fulflix/common/app/base/persistence/JpaTestBase.java
+++ b/app-common/src/test/java/io/fulflix/common/app/base/persistence/JpaTestBase.java
@@ -1,0 +1,43 @@
+package io.fulflix.common.app.base.persistence;
+
+import io.fulflix.common.app.jpa.JpaConfig;
+import io.fulflix.common.web.base.TestBase;
+import jakarta.annotation.Resource;
+import jakarta.persistence.EntityManager;
+import java.util.function.Supplier;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+// TODO Test 환경에서 사용 될 TestJpaAuditingAwareConfig 설정 적용 필요
+@DataJpaTest
+@Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public abstract class JpaTestBase extends TestBase {
+
+    @Resource
+    protected EntityManager entityManager;
+
+    protected <T> T executeWithPersistContextClear(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } finally {
+            entityManager.clear();
+        }
+    }
+
+    protected void executeWithFlush(Runnable runnable) {
+        try {
+            runnable.run();
+        } finally {
+            entityManager.flush();
+        }
+    }
+
+    protected void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
JPA를 이용한 persistence 계층 TC 작성 시 반복적으로 작성되는 설정 부를 추출하여, 상속을 통해 손쉽게 test 작성 환경을 구성하고, 일관된 test 실행 환경을 보장 할 수 있는 공통 설정 부를 구현합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 @DataJpaTest 기반의 Custom JpaTestBase 구현

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 

## 💬 리뷰 요구사항

> 

## 📚 참고 자료

> 

---
