### PR TITLE
feat: user create api

### DIFF
--- a/user-app/src/main/java/io/fulflix/user/UserApp.java
+++ b/user-app/src/main/java/io/fulflix/user/UserApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @PropertySources({
     @PropertySource(
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.PropertySources;
         factory = YamlPropertySourceFactory.class
     )
 })
+@EnableAsync
 @SpringBootApplication(scanBasePackages = BASE_PACKAGE)
 public class UserApp {
 

--- a/user-app/src/main/java/io/fulflix/user/api/UserController.java
+++ b/user-app/src/main/java/io/fulflix/user/api/UserController.java
@@ -1,0 +1,36 @@
+package io.fulflix.user.api;
+
+import static io.fulflix.common.web.utils.ResponseEntityUtils.created;
+import static io.fulflix.user.api.UserController.BASE_USER_PATH;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+import io.fulflix.user.api.dto.UserCreateRequest;
+import io.fulflix.user.application.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    path = BASE_USER_PATH,
+    consumes = APPLICATION_JSON_VALUE,
+    produces = APPLICATION_JSON_VALUE
+)
+@RequiredArgsConstructor
+public class UserController {
+
+    static final String BASE_USER_PATH = "/user";
+    static final String USER_DETAILS_URI_FORMAT = "/user/{id}"; // TODO auth-app과의 코드 중복 필요
+
+    private final UserService userService;
+
+    @PostMapping
+    ResponseEntity<Void> register(@Valid @RequestBody UserCreateRequest request) {
+        return created(USER_DETAILS_URI_FORMAT, userService.createUser(request));
+    }
+
+}

--- a/user-app/src/main/java/io/fulflix/user/api/dto/UserCreateRequest.java
+++ b/user-app/src/main/java/io/fulflix/user/api/dto/UserCreateRequest.java
@@ -1,0 +1,29 @@
+package io.fulflix.user.api.dto;
+
+import io.fulflix.user.repo.model.Role;
+import io.fulflix.user.repo.model.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+// TODO auth-app과 클래스 중복 개선 필요
+public record UserCreateRequest(
+    @NotBlank(message = "아이디를 입력하세요.")
+    @Size(min = 3, max = 20, message = "아이디는 3자 이상 20자 이하로 입력하세요.")
+    String username,
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    String encodedPassword,
+
+    @NotBlank(message = "이름을 입력하세요.")
+    String name,
+
+    @NotNull(message = "회원 타입을 선택하세요.")
+    Role type
+) {
+
+    public User toEntity() {
+        return User.of(username, encodedPassword, name, type);
+    }
+
+}

--- a/user-app/src/main/java/io/fulflix/user/application/UserService.java
+++ b/user-app/src/main/java/io/fulflix/user/application/UserService.java
@@ -1,0 +1,32 @@
+package io.fulflix.user.application;
+
+import io.fulflix.user.api.dto.UserCreateRequest;
+import io.fulflix.user.repo.model.User;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final EntityManager entityManager;
+
+    @Transactional
+    public Long createUser(UserCreateRequest request) {
+        User transientUser = request.toEntity();
+        User savedUser = saveUser(transientUser);
+
+        return savedUser.getId();
+    }
+
+    private User saveUser(User transientUser) {
+        entityManager.persist(transientUser);
+        entityManager.flush();
+        transientUser.applyUserCreated(transientUser.getId());
+        return transientUser;
+    }
+
+}

--- a/user-app/src/test/java/io/fulflix/fixture/UserFixtures.java
+++ b/user-app/src/test/java/io/fulflix/fixture/UserFixtures.java
@@ -1,0 +1,18 @@
+package io.fulflix.fixture;
+
+import io.fulflix.user.api.dto.UserCreateRequest;
+import io.fulflix.user.repo.model.Role;
+
+public class UserFixtures {
+
+    public static final String USERNAME = "hong-gd";
+    public static final String NAME = "홍길동";
+
+    public static final UserCreateRequest USER_CREATE_REQUEST = new UserCreateRequest(
+        USERNAME,
+        "endcoded password",
+        NAME,
+        Role.MASTER_ADMIN
+    );
+
+}

--- a/user-app/src/test/java/io/fulflix/user/api/UserApiTestHelper.java
+++ b/user-app/src/test/java/io/fulflix/user/api/UserApiTestHelper.java
@@ -1,0 +1,14 @@
+package io.fulflix.user.api;
+
+import io.fulflix.common.web.base.presentation.WebMvcTestBase;
+import io.fulflix.user.application.UserService;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(controllers = UserController.class)
+public class UserApiTestHelper extends WebMvcTestBase {
+    
+    @MockBean
+    protected UserService userService;
+
+}

--- a/user-app/src/test/java/io/fulflix/user/api/UserControllerTest.java
+++ b/user-app/src/test/java/io/fulflix/user/api/UserControllerTest.java
@@ -1,0 +1,46 @@
+package io.fulflix.user.api;
+
+import static io.fulflix.common.web.utils.UriComponentUtils.toResourceUri;
+import static io.fulflix.fixture.UserFixtures.USER_CREATE_REQUEST;
+import static io.fulflix.user.api.UserController.BASE_USER_PATH;
+import static io.fulflix.user.api.UserController.USER_DETAILS_URI_FORMAT;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.MimeTypeUtils;
+
+@DisplayName("API:User")
+class UserControllerTest extends UserApiTestHelper {
+
+    @Test
+    @DisplayName("[회원 생성][POST:201]")
+    void create() throws Exception {
+        // Given
+        final Long expectedUserId = 1L;
+        final URI expectedResourceUri = toResourceUri(USER_DETAILS_URI_FORMAT, expectedUserId);
+        given(userService.createUser(USER_CREATE_REQUEST)).willReturn(expectedUserId);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post(BASE_USER_PATH)
+            .contentType(MimeTypeUtils.APPLICATION_JSON_VALUE)
+            .accept(MimeTypeUtils.APPLICATION_JSON_VALUE)
+            .content(objectMapper.writeValueAsBytes(USER_CREATE_REQUEST))
+        );
+
+        // Then
+        resultActions.andDo(print())
+            .andExpect(header().stringValues(
+                HttpHeaders.LOCATION, expectedResourceUri.toString()
+            ))
+            .andExpect(status().isCreated());
+    }
+
+}

--- a/web-common/src/main/java/io/fulflix/common/web/utils/ResponseEntityUtils.java
+++ b/web-common/src/main/java/io/fulflix/common/web/utils/ResponseEntityUtils.java
@@ -1,16 +1,17 @@
 package io.fulflix.common.web.utils;
 
+import java.net.URI;
 import org.springframework.http.ResponseEntity;
 
 public class ResponseEntityUtils {
 
     public static ResponseEntity<Void> created(String uriFormat, Object path) {
-        return ResponseEntity.created(
-                UriComponentUtils.toResourceUri(
-                    uriFormat,
-                    path
-                ))
+        return ResponseEntity.created(toResourceUri(uriFormat, path))
             .build();
+    }
+
+    private static URI toResourceUri(String uriFormat, Object path) {
+        return UriComponentUtils.toResourceUri(uriFormat, path);
     }
 
 }


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
회원 생성 API를 구현합니다. 회원 저장 시 생성 주체에 해당하는 createdBy 설정을 위해 비영속 상태의 User를 영속화 한 후, DB로 부터 부여된 PK 값을 생성 주체에 설정하고 merge하여 동일 트랜잭션 내에서 회원 생성 주체 정보가 같이 저장될 수 있도록 구현합니다.

회원 생성 API 성공 시, 201 Created 응답 코드와 Request Header의 Location 필드에 생성된 Resource를 조회할 수 있는 URI를 제공합니다.

회원 API 처리 과정에서 발생하는 예외의 비동기 이벤트 처리를 위한 @EnableAsync 설정을 추가합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 비영속 상태의 회원 영속 처리 후 DB로 부터 부여된 PK 값을 이용한 생성 주체 데이터 설정
- 📌 회원 생성 API TC 작성
- 📌 회원 도메인 관련 TC 작성 시 반복적으로 작성되는 fixture 정의 및 별도 클래스로 추출

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 회원 생성 API에 대한 TC를 작성 후 정상적으로 동작함을 확인하였습니다.

## 💬 리뷰 요구사항

> 

## 📚 참고 자료

> 

---
