### PR TITLE
build: add eureka-server module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,8 @@ subprojects {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
 
-        implementation 'org.springframework.boot:spring-boot-starter-actuator'
-        implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-        implementation 'io.github.openfeign:feign-micrometer'
-        implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+        implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+        implementation("org.springframework.boot:spring-boot-starter-actuator")
 
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/eureka/build.gradle
+++ b/eureka/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+}

--- a/eureka/src/main/java/io/fulflix/eureka/EurekaApp.java
+++ b/eureka/src/main/java/io/fulflix/eureka/EurekaApp.java
@@ -1,0 +1,15 @@
+package io.fulflix.eureka;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@EnableEurekaServer
+@SpringBootApplication
+public class EurekaApp {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EurekaApp.class, args);
+    }
+
+}

--- a/eureka/src/main/java/io/fulflix/eureka/config/SecurityConfig.java
+++ b/eureka/src/main/java/io/fulflix/eureka/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package io.fulflix.eureka.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+            .httpBasic(httpBasicConfigurer -> httpBasicConfigurer.init(http))
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            )
+            .build();
+    }
+
+}

--- a/eureka/src/main/resources/application.yml
+++ b/eureka/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+server.port: 8761
+
+spring:
+  application.name: eureka-server
+  security:
+    user:
+      name: admin
+      password: admin
+
+eureka:
+  server:
+    enable-self-preservation: false
+  client:
+    register-with-eureka: false
+    fetch-registry: false

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,4 @@ rootProject.name = 'fulflix'
 
 include("web-common", "auth-app")
 include("app-common", "user-app")
+include("eureka")


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
MSA 환경에서 각자의 역할과 책임을 가진 수 많은 인스턴스는 고가용성을 위해 빈번하게 확장/축소하고, 서비스 제공을 위해 필요에 따라 다른 인스턴스와 통신하게 됩니다. 

service-discovery는 인스턴스의 연결 정보를 meta-data 기반으로 수집하여, 인스턴스에 대한 정보를 기록하고 제공하는 역할을 수행합니다.

스케일링 과정에서 인스턴스가 확장/축소를 반복하며 동적으로 변경되는 인스턴스의 연결 정보(ip, port)를 다른 인스턴스에게  전달하기 위해 service-discovery 중 하나인 spring cloud eureka를 구성합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 eureka-server 기본 설정 구성
- 📌 spring-security http-basic authentication 기반의 설정 환경 구성
- 📌 eureka-server 모듈 등록
- 📌 아직 사용하지 않는 zipkin 관련 의존성 제거

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> spring-security의 http-basic authentication이 적용된 eureka-server 구동 여부를 확인하였습니다.

## 💬 리뷰 요구사항

> 

## 📚 참고 자료

> 

---
