### PR TITLE
config: feign-client common configurations

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -21,6 +21,7 @@ val webCommonModule = ":web-common"
 dependencies {
     api(project(webCommonModule))
     api("org.springframework.boot:spring-boot-starter-data-jpa")
+    api("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     runtimeOnly("com.mysql:mysql-connector-j")
 

--- a/app-common/src/main/java/io/fulflix/common/app/feign/FeignClientConfig.java
+++ b/app-common/src/main/java/io/fulflix/common/app/feign/FeignClientConfig.java
@@ -1,0 +1,20 @@
+package io.fulflix.common.app.feign;
+
+import static io.fulflix.common.web.utils.PropertiesCombineUtils.BASE_PACKAGE;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignClientConfig {
+
+    private static final String FEIGN_CLIENT_PACKAGE = "infra.client";
+    public static final String FEIGN_CLIENT_BASE_PACKAGE =
+        BASE_PACKAGE + "." + FEIGN_CLIENT_PACKAGE;
+
+    @Bean
+    public RequestHeaderInterceptor requestHeaderInterceptor() {
+        return new RequestHeaderInterceptor();
+    }
+
+}

--- a/app-common/src/main/java/io/fulflix/common/app/feign/RequestHeaderInterceptor.java
+++ b/app-common/src/main/java/io/fulflix/common/app/feign/RequestHeaderInterceptor.java
@@ -1,0 +1,16 @@
+package io.fulflix.common.app.feign;
+
+import static io.fulflix.common.app.context.UserContextHolderInterceptor.X_USER_ID;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import io.fulflix.common.app.context.UserContextHolder;
+
+public class RequestHeaderInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        requestTemplate.header(X_USER_ID, String.valueOf(UserContextHolder.getCurrentUser()));
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
micro-service간 HTTP 통신 시 간편한 사용을 위해 spring cloud에서 제공하는 선언현 Http Client open-feign의 의존성과 공통 환경 설정을 구성합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 app-common: open-feign 의존성 추가
- 📌 fulflix 내부 통신 시 필요한 공통 설정 구성
- 📌 각 micro-service간 통신 시 필요한 X-USER-ID 설정을 위해 UserContextHodler로 부터 현재 사용자 정보를 FeignClient 구현체에 설정하는 Interceptor 구현

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> project에 구현된 전체 TC가 정상 작동함을 확인하였습니다.

## 💬 리뷰 요구사항

각 micro-service는 feign-client 사용을 위해 entry-point에 아래와 같이 base-pacakge가 명시된 @EnableFeignClients를 설정합니다.
```java
@EnableFeignClients(basePackages = FEIGN_CLIENT_BASE_PACKAGE)
@SpringBootApplication(scanBasePackages = BASE_PACKAGE)
public class UserApp {

    public static void main(String[] args) {
        SpringApplication.run(UserApp.class, args);
    }

}
```

공통 설정이 적용된 feign-client 사용을 위해 각 feign-cleint의 configurations에 FeignClientConfig를 설정합니다. 
```java
@FeignClient(configuration = FeignClientConfig.class)
public interface HubFeignClient {

}
```

## 📚 참고 자료

> 

---
