### PR TITLE
config: add feign client configuration to auth app

### DIFF
--- a/app-common/src/main/java/io/fulflix/common/app/jpa/audit/UserAuditorAwareConfig.java
+++ b/app-common/src/main/java/io/fulflix/common/app/jpa/audit/UserAuditorAwareConfig.java
@@ -11,7 +11,7 @@ public class UserAuditorAwareConfig {
 
     @Bean
     public AuditorAware<Long> getCurrentAuditor() {
-        return () -> Optional.of(UserContextHolder.getCurrentUser())
+        return () -> Optional.ofNullable(UserContextHolder.getCurrentUser())
             .map(Long.class::cast);
     }
 

--- a/app-common/src/main/resources/logback-spring-dev.xml
+++ b/app-common/src/main/resources/logback-spring-dev.xml
@@ -9,7 +9,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.springframework.web" level="DEBUG"/>
+  <logger name="org.springframework.web" level="INFO"/>
   <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
   <logger name="org.hibernate.SQL_SLOW" level="INFO"/>
   <logger name="org.hibernate.stat" level="DEBUG"/>

--- a/app-common/src/main/resources/properties/eureka.yml
+++ b/app-common/src/main/resources/properties/eureka.yml
@@ -12,4 +12,3 @@ eureka:
     prefer-ip-address: true
     lease-renewal-interval-in-seconds: 10
     lease-expiration-duration-in-seconds: 30
-    hostname: user-app

--- a/app-common/src/main/resources/properties/jpa.yml
+++ b/app-common/src/main/resources/properties/jpa.yml
@@ -7,7 +7,6 @@ spring:
         default_batch_fetch_size: 1000
         format_sql: true
         highlight_sql: true
-        generate_statistics: true
         jdbc.log-warnings: true
         session.events.log.log_queries_slower_than_ms: 300
         jdbc:
@@ -19,6 +18,9 @@ spring:
   config.activate.on-profile: test
   jpa:
     hibernate.ddl-auto: create-drop
+    properties:
+      hibernate:
+        generate_statistics: true
 ---
 spring:
   config.activate.on-profile: local

--- a/auth-app/build.gradle
+++ b/auth-app/build.gradle
@@ -6,6 +6,7 @@ ext {
 dependencies {
     implementation project(WEB_COMMON_MODULE)
     implementation("org.springframework.security:spring-security-crypto")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("io.jsonwebtoken:jjwt-api:${JJWT_VERSION}")
     implementation("io.jsonwebtoken:jjwt-jackson:${JJWT_VERSION}")
     implementation("io.jsonwebtoken:jjwt-impl:${JJWT_VERSION}")

--- a/auth-app/src/main/java/io/fulflix/auth/AuthApp.java
+++ b/auth-app/src/main/java/io/fulflix/auth/AuthApp.java
@@ -6,9 +6,11 @@ import io.fulflix.auth.utils.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication(scanBasePackages = BASE_PACKAGE)
 @EnableConfigurationProperties(JwtProperties.class)
+@EnableFeignClients(basePackages = "io.fulflix.infra.client")
 public class AuthApp {
 
     public static void main(String[] args) {

--- a/auth-app/src/main/java/io/fulflix/auth/application/AuthenticationService.java
+++ b/auth-app/src/main/java/io/fulflix/auth/application/AuthenticationService.java
@@ -42,7 +42,7 @@ public class AuthenticationService {
     ) {
         boolean matches = passwordEncoder.matches(
             signInRequest.password(),
-            userCredentialResponse.EncodedPassword()
+            userCredentialResponse.encodedPassword()
         );
 
         if (!matches) {

--- a/auth-app/src/main/java/io/fulflix/auth/application/AuthenticationService.java
+++ b/auth-app/src/main/java/io/fulflix/auth/application/AuthenticationService.java
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthenticationService {
 
-    private final UserAppClient userAppClient;
     private final PasswordEncoder passwordEncoder;
     private final TokenIssueService tokenIssueService;
+    private final UserAppClient userAppClient;
 
     public String authenticate(SignInRequest signInRequest) {
         FulflixPrincipal principal = verifyUser(signInRequest);

--- a/auth-app/src/main/java/io/fulflix/infra/client/UserAppClient.java
+++ b/auth-app/src/main/java/io/fulflix/infra/client/UserAppClient.java
@@ -1,13 +1,36 @@
 package io.fulflix.infra.client;
 
+import static io.fulflix.infra.client.UserAppClient.USER_APP_CLIENT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import io.fulflix.auth.api.dto.CreatePrincipalRequest;
 import io.fulflix.infra.client.dto.UserCredentialResponse;
 import io.fulflix.infra.client.dto.UserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
+@FeignClient(USER_APP_CLIENT)
 public interface UserAppClient {
 
-    UserResponse createPrincipal(CreatePrincipalRequest createPrincipalRequest);
+    String USER_APP_CLIENT = "user-app";
+    String CREATE_PRINCIPAL_URI = "/principal";
+    String RETRIEVE_USER_CREDENTIAL_URI = "/credential/{username}";
 
-    UserCredentialResponse retrieveUserCredential(String username);
+    @PostMapping(
+        path = CREATE_PRINCIPAL_URI,
+        consumes = APPLICATION_JSON_VALUE,
+        produces = APPLICATION_JSON_VALUE
+    )
+    UserResponse createPrincipal(@RequestBody CreatePrincipalRequest createPrincipalRequest);
+
+    @GetMapping(
+        path = RETRIEVE_USER_CREDENTIAL_URI,
+        consumes = APPLICATION_JSON_VALUE,
+        produces = APPLICATION_JSON_VALUE
+    )
+    UserCredentialResponse retrieveUserCredential(@PathVariable String username);
 
 }

--- a/auth-app/src/main/java/io/fulflix/infra/client/dto/UserCredentialResponse.java
+++ b/auth-app/src/main/java/io/fulflix/infra/client/dto/UserCredentialResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 public record UserCredentialResponse(
     Long id,
     String username,
-    String EncodedPassword,
+    String encodedPassword,
     Role role,
     LocalDateTime createdAt
 ) {

--- a/auth-app/src/main/resources/application.yml
+++ b/auth-app/src/main/resources/application.yml
@@ -9,3 +9,4 @@ spring:
     import:
       - classpath:properties/jwt.yml
       - classpath:properties/logging.yml
+      - classpath:properties/eureka.yml

--- a/auth-app/src/main/resources/properties/eureka.yml
+++ b/auth-app/src/main/resources/properties/eureka.yml
@@ -1,0 +1,14 @@
+spring:
+  config.activate.on-profile: local
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://admin:admin@host.docker.internal:8761/eureka/
+
+  instance:
+    prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 10
+    lease-expiration-duration-in-seconds: 30

--- a/auth-app/src/main/resources/properties/jwt.yml
+++ b/auth-app/src/main/resources/properties/jwt.yml
@@ -2,15 +2,13 @@ spring:
   config.activate.on-profile: test
 jwt:
   audience: fulflix-service-app
-  expiration-minutes: 30
+  expiration-minutes: 1
   secret-key: test-fulflix-authenticate-secret-key
-logging:
-  level:
-    root: INFO
-    org.springframework.web: DEBUG
-
-  pattern:
-    #    console: "%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n"
-    console: "%d{yyyy-MM-dd HH:mm:ss} %highlight([%thread] %-5level) %logger{36} - %msg%n"
 
 ---
+spring:
+  config.activate.on-profile: local
+jwt:
+  audience: fulflix-service-app
+  expiration-minutes: 30
+  secret-key: local-fulflix-authenticate-secret-key

--- a/auth-app/src/main/resources/properties/logging.yml
+++ b/auth-app/src/main/resources/properties/logging.yml
@@ -1,10 +1,6 @@
-spring:
-  profiles:
-    active: test
-
 logging:
   level:
     root: INFO
-    org.springframework.web: DEBUG
+    org.springframework.web: INFO
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} %highlight([%thread] %-5level) %logger{36} - %msg%n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower_case_table_names=1
     ports:
       - 3306:3306
-    volumes:
-      - ./db/conf.d:/etc/mysql/conf.d
-      - ./db/data/porko:/var/lib/mysql
-      - ./db/initdb.d:/docker-entrypoint-initdb.d
     environment:
       - TZ=Asia/Seoul
       - MYSQL_DATABASE=fulflix

--- a/docs/client/auth-app.http
+++ b/docs/client/auth-app.http
@@ -1,0 +1,24 @@
+## 회원가입 API
+POST http://localhost:8080/auth/sign-up
+Content-Type: application/json
+
+{
+  "username": "hong-gd",
+  "password": "password",
+  "name": "홍길동",
+  "type": "MASTER_ADMIN"
+}
+
+###
+
+## 로그인 API
+POST http://localhost:8080/auth/sign-in
+Content-Type: application/json
+
+{
+  "username": "hong-gd",
+  "password": "password"
+}
+> {%
+  client.global.set("access_token", response.headers.valueOf("Authorization"))
+%}

--- a/user-app/src/main/java/io/fulflix/user/api/authenticate/dto/UserCredentialResponse.java
+++ b/user-app/src/main/java/io/fulflix/user/api/authenticate/dto/UserCredentialResponse.java
@@ -2,12 +2,14 @@ package io.fulflix.user.api.authenticate.dto;
 
 import io.fulflix.user.repo.model.Role;
 import io.fulflix.user.repo.model.User;
+import java.time.LocalDateTime;
 
 public record UserCredentialResponse(
-    Long userId,
+    Long id,
     String username,
     String encodedPassword,
-    Role role
+    Role role,
+    LocalDateTime createdAt
 ) {
 
     public static UserCredentialResponse from(User user) {
@@ -15,7 +17,8 @@ public record UserCredentialResponse(
             user.getId(),
             user.getUsername(),
             user.getPassword(),
-            user.getRole()
+            user.getRole(),
+            user.getCreatedAt()
         );
     }
 

--- a/user-app/src/main/java/io/fulflix/user/application/UserAuthenticateUseCase.java
+++ b/user-app/src/main/java/io/fulflix/user/application/UserAuthenticateUseCase.java
@@ -21,6 +21,8 @@ public class UserAuthenticateUseCase {
 
     @Transactional
     public Long createUser(CreatePrincipalRequest request) {
+        // TODO validate(request);
+
         User transientUser = request.toEntity();
         User savedUser = saveUser(transientUser);
 


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
app-module 의존성이 없는 auth-app의 feign client 사용을 위한 eureka와 feign-client 설정을 구성합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 open-feign 의존성 추가 및 base packages 환경 설정 적용
- 📌 eureka 연동을 위한 환경 설정 구성
- 📌 auditing을 위환 현재 요청 사용자 정보가 없는 경우 발생하는 오류 수정(Optional.of -> Optional.ofNullable)
- 📌 로그인 응답 객체 파싱 과정에서 필드명 불일치로 발생하는 오류 수정
- 📌 local profiles에서 가독성을 위한 일부 log level 설정 변경

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> intellij http-client를 이용하여 user-app과 사용자 생성, 사용자 자격 증명 조회 API가 성공적으로 호출됨을 확인하였습니다.

## 💬 리뷰 요구사항

> local profiles에서 과도하게 출력 되는 일부 log의 level이 조정되었습니다.
> - web INFO -> DEBUG
> - jpa transaction statistic log 출력 off

## 📚 참고 자료

> 

---
