### PR TITLE
feat: user mypage

### DIFF
--- a/app-common/src/main/java/io/fulflix/common/app/context/UserContextHolder.java
+++ b/app-common/src/main/java/io/fulflix/common/app/context/UserContextHolder.java
@@ -1,15 +1,19 @@
 package io.fulflix.common.app.context;
 
+import java.util.Optional;
+
 public class UserContextHolder {
 
-    private static final ThreadLocal<String> currentUser = new ThreadLocal<>();
+    private static final ThreadLocal<Optional<String>> currentUser = new ThreadLocal<>();
 
     public static void setCurrentUser(String userId) {
-        currentUser.set(userId);
+        currentUser.set(Optional.ofNullable(userId));
     }
 
-    public static String getCurrentUser() {
-        return currentUser.get();
+    public static Long getCurrentUser() {
+        return currentUser.get()
+            .map(Long::parseLong)
+            .orElse(0L);
     }
 
     public static void clear() {

--- a/docs/client/gateway.http
+++ b/docs/client/gateway.http
@@ -22,3 +22,12 @@ Content-Type: application/json
 > {%
   client.global.set("access_token", response.headers.valueOf("Authorization"))
 %}
+
+###
+
+## 마이 페이지 API
+GET http://localhost:8088/user/me
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+###

--- a/gateway/src/main/resources/properties/routing.yml
+++ b/gateway/src/main/resources/properties/routing.yml
@@ -12,6 +12,6 @@ spring:
         - id: user-app-authenticated
           uri: lb://user-app
           predicates:
-            - Path=/auth/**
+            - Path=/user/**
           filters:
             - JwtAuthorizationFilter

--- a/user-app/src/main/java/io/fulflix/user/api/mypage/UserMyPageController.java
+++ b/user-app/src/main/java/io/fulflix/user/api/mypage/UserMyPageController.java
@@ -1,0 +1,31 @@
+package io.fulflix.user.api.mypage;
+
+import static io.fulflix.user.api.mypage.UserMyPageController.USER_BASE_PATH;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+import io.fulflix.common.app.context.annotation.CurrentUser;
+import io.fulflix.user.application.UserMyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    path = USER_BASE_PATH,
+    consumes = APPLICATION_JSON_VALUE,
+    produces = APPLICATION_JSON_VALUE
+)
+@RequiredArgsConstructor
+public class UserMyPageController {
+
+    static final String USER_BASE_PATH = "/user";
+    private final UserMyPageService userMyPageService;
+
+    @GetMapping("/me")
+    ResponseEntity<?> me(@CurrentUser Long currentUser) {
+        return ResponseEntity.ok(userMyPageService.loadUserById(currentUser));
+    }
+
+}

--- a/user-app/src/main/java/io/fulflix/user/api/mypage/dto/UserResponse.java
+++ b/user-app/src/main/java/io/fulflix/user/api/mypage/dto/UserResponse.java
@@ -1,0 +1,22 @@
+package io.fulflix.user.api.mypage.dto;
+
+import io.fulflix.user.repo.model.User;
+import java.time.LocalDateTime;
+
+public record UserResponse(
+    Long id,
+    String username,
+    String name,
+    LocalDateTime createdAt
+) {
+
+    public static UserResponse from(User user) {
+        return new UserResponse(
+            user.getId(),
+            user.getUsername(),
+            user.getName(),
+            user.getCreatedAt()
+        );
+    }
+
+}

--- a/user-app/src/main/java/io/fulflix/user/application/UserMyPageService.java
+++ b/user-app/src/main/java/io/fulflix/user/application/UserMyPageService.java
@@ -1,0 +1,23 @@
+package io.fulflix.user.application;
+
+import io.fulflix.user.api.mypage.dto.UserResponse;
+import io.fulflix.user.exception.UserErrorCode;
+import io.fulflix.user.exception.UserException;
+import io.fulflix.user.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserMyPageService {
+
+    private final UserRepo userRepo;
+
+    public UserResponse loadUserById(Long id) {
+        return userRepo.findById(id).map(UserResponse::from)
+            .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST, id));
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
현재 인증된 사용자 정보를 이용한 마이페이지 API를 구현합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 인증되지 않은 사용자의 요청도 처리하기 위해 기존 ThraedLocal<Long>으로 구성된 UserContextHolder를 ThreadLocal<Optional<String>>으로 처리
- 📌 @CurrentUser를 적용한 GET /user/me API 구현
- 📌 Intellij http-cleint를 이용한 gw->user-app 마이페이지 API 호출 test 구현

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> Intellij http-client를 이용하여 로그인 후 gw의 인증 필터를 거쳐 @CurrentUser에 설정된 현재 인증된 사용자의 번호를 이용하여 사용자 마이페이지 API가 정상 동작함을 확인하였습니다.

## 💬 리뷰 요구사항
local 환경에서 아래와 같은 과정으로 마이페이지 API를 호출 할 수 있습니다.

1. gateway.http의 로그인 API 호출
```http
## 로그인 API
POST http://localhost:8088/auth/sign-in
Content-Type: application/json

{
  "username": "hong-gd",
  "password": "password"
}
> {%
  client.global.set("access_token", response.headers.valueOf("Authorization"))
%}

###
```

2. gateway.http의 마이페이지 API 호출
```http
## 마이 페이지 API
GET http://localhost:8088/user/me
Content-Type: application/json
Authorization: Bearer {{access_token}}

###

```

3. GW의 JWT 검증 필터를 거친 후 인증된 사용자 정보의 번호는 @CurrentUser Long currentUser를 통해 주입 받을 수 있습니다.
```java
@GetMapping("/me")
ResponseEntity<UserResponse> me(@CurrentUser Long currentUser) {
    return ResponseEntity.ok(userMyPageService.loadUserById(currentUser));
}
```

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
