### PR TITLE
build: zipkin for distributed trace

### DIFF
--- a/app-common/src/main/resources/application.yml
+++ b/app-common/src/main/resources/application.yml
@@ -6,5 +6,6 @@ spring:
       - classpath:properties/logging.yml
       - classpath:properties/eureka.yml
       - classpath:properties/actuator.yml
+      - classpath:properties/zipkin.yml
   profiles:
     active: local

--- a/app-common/src/main/resources/properties/zipkin.yml
+++ b/app-common/src/main/resources/properties/zipkin.yml
@@ -1,0 +1,3 @@
+management:
+  zipkin.tracing.endpoint: http://host.docker.internal:9411/api/v2/spans
+  tracing.sampling.probability: 1.0

--- a/auth-app/src/main/resources/application.yml
+++ b/auth-app/src/main/resources/application.yml
@@ -10,3 +10,4 @@ spring:
       - classpath:properties/jwt.yml
       - classpath:properties/logging.yml
       - classpath:properties/eureka.yml
+      - classpath:properties/zipkin.yml

--- a/auth-app/src/main/resources/properties/zipkin.yml
+++ b/auth-app/src/main/resources/properties/zipkin.yml
@@ -1,0 +1,3 @@
+management:
+  zipkin.tracing.endpoint: http://host.docker.internal:9411/api/v2/spans
+  tracing.sampling.probability: 1.0

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ subprojects {
         implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
         implementation("org.springframework.boot:spring-boot-starter-actuator")
 
+        implementation("io.micrometer:micrometer-tracing-bridge-brave")
+        implementation("io.github.openfeign:feign-micrometer")
+        implementation("io.zipkin.reporter2:zipkin-reporter-brave")
+
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.testcontainers:junit-jupiter'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       - MYSQL_ROOT_PASSWORD=password
       - MYSQL_USER=fulflix
       - MYSQL_PASSWORD=fulflix
+
+  fulflix-zipkin:
+    image: openzipkin/zipkin
+    container_name: zipkin
+    ports:
+      - 9411:9411

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -11,3 +11,4 @@ spring:
       - classpath:properties/eureka.yml
       - classpath:properties/routing.yml
       - classpath:properties/jwt.yml
+      - classpath:properties/zipkin.yml

--- a/gateway/src/main/resources/properties/zipkin.yml
+++ b/gateway/src/main/resources/properties/zipkin.yml
@@ -1,0 +1,3 @@
+management:
+  zipkin.tracing.endpoint: http://host.docker.internal:9411/api/v2/spans
+  tracing.sampling.probability: 1.0


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
MSA 환경에서 분산 추적을 위한 zipkin 환경 설정을 구성합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 docker-compose에 zipkin 추가
- 📌 app-common, gateway, auth-app 모듈에 zipkin 환경 설정 구성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
local 환경에서 전체 모듈 구동 후, 회원가입, 로그인, 마이페이지 API를 호출하여 zipkin dashboard에 정상적으로 요청이 추적됨을 확인하였습니다.

## 💬 리뷰 요구사항

app-common 의존성을 포함하는 모듈은 별도 설정 없이 분산 추적이 가능한 환경이 구성됩니다. 분산 추적은 아래 zipkin dashboard에서 확인 하실 수 있습니다. 
- [zipkin dashboard](http://localhost:9411/zipkin/)

![image](https://github.com/user-attachments/assets/ae00fb30-661c-4b95-b68f-c77327373d91)

![chrome-capture-2024-9-11 (1)](https://github.com/user-attachments/assets/d4f4d431-85f3-4219-a313-5892a0e15a0a)

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
