### PR TITLE
feat: apply create user username validation

### DIFF
--- a/auth-app/src/test/java/io/fulflix/auth/application/AuthenticationServiceTest.java
+++ b/auth-app/src/test/java/io/fulflix/auth/application/AuthenticationServiceTest.java
@@ -28,8 +28,8 @@ class AuthenticationServiceTest extends AuthServiceTestHelper {
         @DisplayName("존재하지 않는 회원인 경우 예외 발생")
         void throwException_whenUserNotExist() {
             // Given
-            given(userAppClient.retrieveUserCredential(anyString())).willThrow(
-                RuntimeException.class);
+            given(userAppClient.retrieveUserCredential(anyString()))
+                .willThrow(RuntimeException.class);
 
             // When & Then
             assertThatExceptionOfType(RuntimeException.class)
@@ -41,8 +41,8 @@ class AuthenticationServiceTest extends AuthServiceTestHelper {
         @DisplayName("비밀번호가 일치하지 않는 경우 예외 발생")
         void throwException_whenPasswordNotMatched() {
             // Given
-            given(userAppClient.retrieveUserCredential(anyString())).willReturn(
-                USER_DETAILS_RESPONSE);
+            given(userAppClient.retrieveUserCredential(anyString()))
+                .willReturn(USER_DETAILS_RESPONSE);
             given(passwordEncoder.matches(
                 SIGN_IN_REQUEST.password(),
                 USER_DETAILS_RESPONSE.encodedPassword())
@@ -65,8 +65,8 @@ class AuthenticationServiceTest extends AuthServiceTestHelper {
         @DisplayName("인증 성공 후 access token 발급")
         void authentication() {
             // Given
-            given(userAppClient.retrieveUserCredential(anyString())).willReturn(
-                USER_DETAILS_RESPONSE);
+            given(userAppClient.retrieveUserCredential(anyString()))
+                .willReturn(USER_DETAILS_RESPONSE);
 
             given(passwordEncoder.matches(
                 SIGN_IN_REQUEST.password(),

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ subprojects {
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.testcontainers:junit-jupiter'
+        testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
+
     }
 
     ext['springCloudVersion'] = '2023.0.3'

--- a/user-app/src/main/java/io/fulflix/user/application/UserAuthenticateUseCase.java
+++ b/user-app/src/main/java/io/fulflix/user/application/UserAuthenticateUseCase.java
@@ -1,8 +1,10 @@
 package io.fulflix.user.application;
 
+import static io.fulflix.user.exception.UserErrorCode.DUPLICATED_USERNAME;
+import static io.fulflix.user.exception.UserErrorCode.NOT_EXIST;
+
 import io.fulflix.user.api.authenticate.dto.CreatePrincipalRequest;
 import io.fulflix.user.api.authenticate.dto.UserCredentialResponse;
-import io.fulflix.user.exception.UserErrorCode;
 import io.fulflix.user.exception.UserException;
 import io.fulflix.user.repo.UserRepo;
 import io.fulflix.user.repo.model.User;
@@ -21,12 +23,18 @@ public class UserAuthenticateUseCase {
 
     @Transactional
     public Long createUser(CreatePrincipalRequest request) {
-        // TODO validate(request);
+        validateDuplicatedUsername(request.username());
 
         User transientUser = request.toEntity();
         User savedUser = saveUser(transientUser);
 
         return savedUser.getId();
+    }
+
+    private void validateDuplicatedUsername(String username) {
+        if (userRepo.existsByUsername(username)) {
+            throw new UserException(DUPLICATED_USERNAME, username);
+        }
     }
 
     private User saveUser(User transientUser) {
@@ -39,7 +47,7 @@ public class UserAuthenticateUseCase {
     public UserCredentialResponse loadUserCredentialByUsername(String username) {
         return userRepo.findByUsername(username)
             .map(UserCredentialResponse::from)
-            .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST, username));
+            .orElseThrow(() -> new UserException(NOT_EXIST, username));
     }
 
 }

--- a/user-app/src/main/java/io/fulflix/user/exception/UserErrorCode.java
+++ b/user-app/src/main/java/io/fulflix/user/exception/UserErrorCode.java
@@ -1,5 +1,6 @@
 package io.fulflix.user.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.Getter;
@@ -7,8 +8,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum UserErrorCode {
-    NOT_EXIST(NOT_FOUND, "요청에 해당하는 사용자를 찾을 수 없습니다. [%s]");
-
+    NOT_EXIST(NOT_FOUND, "요청에 해당하는 사용자를 찾을 수 없습니다. [%s]"),
+    DUPLICATED_USERNAME(BAD_REQUEST, "이미 존재하는 아이디입니다.[%s]"),
+    ;
+    
     private final HttpStatus status;
     private final String message;
 
@@ -16,4 +19,5 @@ public enum UserErrorCode {
         this.status = status;
         this.message = message;
     }
+
 }

--- a/user-app/src/main/java/io/fulflix/user/repo/UserRepo.java
+++ b/user-app/src/main/java/io/fulflix/user/repo/UserRepo.java
@@ -8,4 +8,6 @@ public interface UserRepo extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
+    boolean existsByUsername(String username);
+
 }

--- a/user-app/src/main/java/io/fulflix/user/repo/model/User.java
+++ b/user-app/src/main/java/io/fulflix/user/repo/model/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
@@ -56,6 +57,19 @@ public class User extends UserAuditable {
 
     public static User of(String username, String password, String name, Role role) {
         return new User(username, password, name, role);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof User user) {
+            return Objects.equals(id, user.id);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
 }

--- a/user-app/src/test/java/io/fulflix/fixture/UserFixtures.java
+++ b/user-app/src/test/java/io/fulflix/fixture/UserFixtures.java
@@ -13,7 +13,7 @@ public class UserFixtures {
     public static final String ENCODED_PASSWORD = "endcoded password";
     public static final Role MASTER_ADMIN_ROLE = Role.MASTER_ADMIN;
 
-    public static final CreatePrincipalRequest USER_CREATE_REQUEST = new CreatePrincipalRequest(
+    public static final CreatePrincipalRequest CREATE_PRINCIPAL_REQUEST = new CreatePrincipalRequest(
         USERNAME,
         ENCODED_PASSWORD,
         NAME,

--- a/user-app/src/test/java/io/fulflix/user/api/authenticate/UserAuthenticateControllerTest.java
+++ b/user-app/src/test/java/io/fulflix/user/api/authenticate/UserAuthenticateControllerTest.java
@@ -1,8 +1,8 @@
 package io.fulflix.user.api.authenticate;
 
 import static io.fulflix.common.web.utils.UriComponentUtils.toResourceUri;
+import static io.fulflix.fixture.UserFixtures.CREATE_PRINCIPAL_REQUEST;
 import static io.fulflix.fixture.UserFixtures.USERNAME;
-import static io.fulflix.fixture.UserFixtures.USER_CREATE_REQUEST;
 import static io.fulflix.fixture.UserFixtures.USER_CREDENTIAL_RESPONSE;
 import static io.fulflix.user.api.authenticate.UserAuthenticateController.GET_AN_USER_CREDENTIAL_URI_FORMAT;
 import static org.mockito.BDDMockito.given;
@@ -33,13 +33,14 @@ class UserAuthenticateControllerTest extends UserApiTestHelper {
             GET_AN_USER_CREDENTIAL_URI_FORMAT,
             expectedUserId
         );
-        given(userAuthenticateUseCase.createUser(USER_CREATE_REQUEST)).willReturn(expectedUserId);
+        given(userAuthenticateUseCase.createUser(CREATE_PRINCIPAL_REQUEST)).willReturn(
+            expectedUserId);
 
         // When
         ResultActions resultActions = mockMvc.perform(post(principalUri)
             .contentType(MimeTypeUtils.APPLICATION_JSON_VALUE)
             .accept(MimeTypeUtils.APPLICATION_JSON_VALUE)
-            .content(objectMapper.writeValueAsBytes(USER_CREATE_REQUEST))
+            .content(objectMapper.writeValueAsBytes(CREATE_PRINCIPAL_REQUEST))
         );
 
         // Then
@@ -62,7 +63,7 @@ class UserAuthenticateControllerTest extends UserApiTestHelper {
             get(GET_AN_USER_CREDENTIAL_URI_FORMAT, USERNAME)
                 .contentType(MimeTypeUtils.APPLICATION_JSON_VALUE)
                 .accept(MimeTypeUtils.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsBytes(USER_CREATE_REQUEST)
+                .content(objectMapper.writeValueAsBytes(CREATE_PRINCIPAL_REQUEST)
                 ));
 
         // Then

--- a/user-app/src/test/java/io/fulflix/user/application/UserAuthenticateUseCaseTest.java
+++ b/user-app/src/test/java/io/fulflix/user/application/UserAuthenticateUseCaseTest.java
@@ -1,0 +1,71 @@
+package io.fulflix.user.application;
+
+import static io.fulflix.fixture.UserFixtures.CREATE_PRINCIPAL_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.fulflix.user.exception.UserErrorCode;
+import io.fulflix.user.exception.UserException;
+import io.fulflix.user.repo.UserRepo;
+import io.fulflix.user.repo.model.User;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+
+@AutoConfigureTestEntityManager
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UseCase:UserAuthenticate")
+class UserAuthenticateUseCaseTest {
+
+    @Mock
+    private UserRepo userRepo;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private UserAuthenticateUseCase userAuthenticateUseCase;
+
+    @Test
+    @DisplayName("회원 생성")
+    void createPrincipal() {
+        // Given
+        User given = CREATE_PRINCIPAL_REQUEST.toEntity();
+        given(userRepo.existsByUsername(anyString())).willReturn(false);
+        doNothing().when(entityManager).persist(given);
+
+        // When
+        Long actual = userAuthenticateUseCase.createUser(CREATE_PRINCIPAL_REQUEST);
+
+        // Then
+        assertThat(actual).isEqualTo(given.getId());
+        verify(entityManager, times(1)).persist(given);
+        verify(entityManager, times(1)).flush();
+    }
+
+    @Test
+    @DisplayName("[예외] 회원 아이디 중복")
+    void throwException_whenUsernameDuplicated() {
+        // Given
+        given(userRepo.existsByUsername(anyString())).willReturn(true);
+
+        // When & Then
+        assertThatExceptionOfType(UserException.class)
+            .isThrownBy(() -> userAuthenticateUseCase.createUser(CREATE_PRINCIPAL_REQUEST))
+            .extracting(UserException::getErrorCode)
+            .isEqualTo(UserErrorCode.DUPLICATED_USERNAME);
+
+        verify(userRepo, times(1)).existsByUsername(anyString());
+    }
+
+}

--- a/web-common/src/test/java/io/fulflix/common/web/base/presentation/OpenFeignClientTestBase.java
+++ b/web-common/src/test/java/io/fulflix/common/web/base/presentation/OpenFeignClientTestBase.java
@@ -1,0 +1,26 @@
+package io.fulflix.common.web.base.presentation;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import jakarta.annotation.Resource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+
+@AutoConfigureWireMock(port = 0)
+public abstract class OpenFeignClientTestBase extends WebMvcTestBase {
+
+    @Resource
+    private WireMockServer wireMockServer;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer.stop();
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void afterEach() {
+        wireMockServer.resetAll();
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
회원 생성 시, UK 제약조건이 설정된 username 항목에 대한 유효성 검증을 적용합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 JPA exists 쿼리를 이용한 회원 username 유효성 검증 부 구현
- 📌 중복된 회원 username에 대한 예외 처리 및 username 중복 에러 코드 정의
- 📌 EntityManager mockfing을 통한 회원 생성 및 회원 username 중복 시 예외 발생 검증 TC 작성
- 📌 feign-client mocking test를 위한 wire-mock 의존성 및 공통 설정 부 구성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.
> 어떤 방법으로 테스트했는지 알려주세요.

회원 생성 usercase에 대한 TC를 작성하고 정상적으로 동작함을 확인하였습니다.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
