### PR TITLE
test: add user mypage api test case

### DIFF
--- a/app-common/src/main/java/io/fulflix/common/app/context/interceptor/UserContextHolderInterceptor.java
+++ b/app-common/src/main/java/io/fulflix/common/app/context/interceptor/UserContextHolderInterceptor.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+// TODO web-common 계층으로 이동
 public class UserContextHolderInterceptor implements HandlerInterceptor {
 
     public static final String X_USER_ID = "X-User-Id";

--- a/user-app/src/test/java/io/fulflix/user/api/UserApiTestHelper.java
+++ b/user-app/src/test/java/io/fulflix/user/api/UserApiTestHelper.java
@@ -2,14 +2,22 @@ package io.fulflix.user.api;
 
 import io.fulflix.common.web.base.presentation.WebMvcTestBase;
 import io.fulflix.user.api.authenticate.UserAuthenticateController;
+import io.fulflix.user.api.mypage.UserMyPageController;
 import io.fulflix.user.application.UserAuthenticateUseCase;
+import io.fulflix.user.application.UserMyPageService;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@WebMvcTest(controllers = UserAuthenticateController.class)
+@WebMvcTest(controllers = {
+    UserAuthenticateController.class,
+    UserMyPageController.class
+})
 public class UserApiTestHelper extends WebMvcTestBase {
 
     @MockBean
     protected UserAuthenticateUseCase userAuthenticateUseCase;
+
+    @MockBean
+    protected UserMyPageService userMyPageService;
 
 }

--- a/user-app/src/test/java/io/fulflix/user/api/mypage/UserMyPageControllerTest.java
+++ b/user-app/src/test/java/io/fulflix/user/api/mypage/UserMyPageControllerTest.java
@@ -35,8 +35,6 @@ class UserMyPageControllerTest extends UserApiTestHelper {
     @Test
     @DisplayName("내 정보 조회")
     void me() throws Exception {
-        // Given
-
         // When
         ResultActions resultActions = mockMvc.perform(get(userMyPageUrl)
             .headers(headers)

--- a/user-app/src/test/java/io/fulflix/user/api/mypage/UserMyPageControllerTest.java
+++ b/user-app/src/test/java/io/fulflix/user/api/mypage/UserMyPageControllerTest.java
@@ -1,0 +1,50 @@
+package io.fulflix.user.api.mypage;
+
+import static io.fulflix.common.app.context.interceptor.UserContextHolderInterceptor.X_USER_ID;
+import static io.fulflix.common.app.context.interceptor.UserRoleContextHolderInterceptor.X_USER_ROLE;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.user.api.UserApiTestHelper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("API:User:MyPage")
+class UserMyPageControllerTest extends UserApiTestHelper {
+
+    private static final HttpHeaders headers = new HttpHeaders();
+    private static final String userMyPageUrl = "/user/me";
+
+    static {
+        final String userId = "1";
+        final String role = Role.MASTER_ADMIN.name();
+
+        headers.add(X_USER_ID, userId);
+        headers.add(X_USER_ROLE, role);
+        headers.add(CONTENT_TYPE, APPLICATION_JSON_VALUE);
+        headers.add(ACCEPT, APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    @DisplayName("내 정보 조회")
+    void me() throws Exception {
+        // Given
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get(userMyPageUrl)
+            .headers(headers)
+        );
+
+        // Then
+        resultActions.andDo(print())
+            .andExpect(status().isOk());
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
인증된 사용자 정보를 이용한 내 정보 조회 API의 Test Case를 구현합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 UserMypage의 /user/me API TC 작성
- 📌 인증된 사용자 정보의 header 설정을 위한 test dummy http header 정의

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> @WebMvcTest를 이용한 Controller Test Case를 작성하고 정상적으로 동작함을 확인 하였습니다.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
