### PR TITLE
feat: naver map direction5 api client

### DIFF
--- a/core/app-core/src/main/java/io/fulflix/common/app/feign/FeignClientErrorDecoderConfig.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/feign/FeignClientErrorDecoderConfig.java
@@ -1,0 +1,74 @@
+package io.fulflix.common.app.feign;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+
+import feign.Request;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.springframework.context.annotation.Bean;
+
+@Slf4j
+public class FeignClientErrorDecoderConfig {
+
+    @Bean
+    public ErrorDecoder decoder() {
+
+        return (methodKey, response) -> {
+            Request request = response.request();
+            log.error(""" 
+                    \s
+                        Request Fail: {}
+                        URL: {} {}
+                        Status: {}
+                        Request Header: {}
+                        Request Body: {}
+                        Response Body: {}
+                    \s""",
+                methodKey,
+                request.httpMethod(),
+                request.url(),
+                response.status(),
+                extractRequestHeader(request),
+                extractRequestBody(request),
+                extractResponseBody(response)
+            );
+
+            return new RuntimeException();
+        };
+    }
+
+    private static String extractRequestHeader(Request request) {
+        Map<String, Collection<String>> headers = request.headers();
+
+        if (Objects.nonNull(headers)) {
+            return headers.toString();
+        }
+        return EMPTY;
+    }
+
+    private static String extractRequestBody(Request request) {
+        byte[] body = request.body();
+
+        if (Objects.nonNull(body)) {
+            new String(body, StandardCharsets.UTF_8);
+        }
+        return EMPTY;
+    }
+
+    private String extractResponseBody(Response response) {
+        try (InputStream responseBodyStream = response.body().asInputStream()) {
+            return IOUtils.toString(responseBodyStream, String.valueOf(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/core/app-core/src/main/resources/properties/eureka.yml
+++ b/core/app-core/src/main/resources/properties/eureka.yml
@@ -1,4 +1,13 @@
 spring:
+  config.activate.on-profile: test
+  cloud:
+    discovery:
+      enabled: false
+
+    config:
+      allow-override: false
+---
+spring:
   config.activate.on-profile: local
 
 eureka:

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverDirectionClient.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverDirectionClient.java
@@ -1,0 +1,30 @@
+package io.fulflix.infra.client.external.naver;
+
+import static io.fulflix.infra.client.external.naver.NaverDirectionClient.NAVER_DIRECTION_API;
+import static io.fulflix.infra.client.external.naver.NaverDirectionClient.NAVER_MAP_DIRECTION_API_URL;
+
+import io.fulflix.common.app.feign.FeignClientErrorDecoderConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = NAVER_DIRECTION_API,
+    url = NAVER_MAP_DIRECTION_API_URL,
+    configuration = {
+        NaverDirectionClientHeaderConfig.class,
+        FeignClientErrorDecoderConfig.class
+    }
+)
+public interface NaverDirectionClient {
+
+    String NAVER_DIRECTION_API = "naver-openapi";
+    String NAVER_MAP_DIRECTION_API_URL = "https://naveropenapi.apigw.ntruss.com";
+
+    @GetMapping(path = "/map-direction/v1/driving")
+    String getDirection(
+        @RequestParam String start,
+        @RequestParam String goal
+    );
+
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverDirectionClient.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverDirectionClient.java
@@ -4,6 +4,7 @@ import static io.fulflix.infra.client.external.naver.NaverDirectionClient.NAVER_
 import static io.fulflix.infra.client.external.naver.NaverDirectionClient.NAVER_MAP_DIRECTION_API_URL;
 
 import io.fulflix.common.app.feign.FeignClientErrorDecoderConfig;
+import io.fulflix.infra.client.external.naver.dto.RouteResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,7 +23,7 @@ public interface NaverDirectionClient {
     String NAVER_MAP_DIRECTION_API_URL = "https://naveropenapi.apigw.ntruss.com";
 
     @GetMapping(path = "/map-direction/v1/driving")
-    String getDirection(
+    RouteResponse getDirection(
         @RequestParam String start,
         @RequestParam String goal
     );

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverDirectionClientHeaderConfig.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverDirectionClientHeaderConfig.java
@@ -1,0 +1,10 @@
+package io.fulflix.infra.client.external.naver;
+
+import org.springframework.context.annotation.Bean;
+
+public class NaverDirectionClientHeaderConfig {
+    @Bean
+    public NaverRequestInterceptor requestInterceptor() {
+        return new NaverRequestInterceptor();
+    }
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverRequestInterceptor.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/NaverRequestInterceptor.java
@@ -1,0 +1,24 @@
+package io.fulflix.infra.client.external.naver;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+public class NaverRequestInterceptor implements RequestInterceptor {
+
+    private static final String X_NCP_APIGW_API_KEY_ID = "X-NCP-APIGW-API-KEY-ID";
+    private static final String X_NCP_APIGW_API_KEY = "X-NCP-APIGW-API-KEY";
+
+    @Value("${naver.client-id}")
+    private String clientId;
+
+    @Value("${naver.client-secret}")
+    private String clientSecret;
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        requestTemplate.header(X_NCP_APIGW_API_KEY_ID, clientId);
+        requestTemplate.header(X_NCP_APIGW_API_KEY, clientSecret);
+    }
+
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/Location.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/Location.java
@@ -1,0 +1,14 @@
+package io.fulflix.infra.client.external.naver.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Location {
+
+    private List<Double> location;
+    private int dir;
+
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/RouteResponse.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/RouteResponse.java
@@ -1,0 +1,18 @@
+package io.fulflix.infra.client.external.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RouteResponse {
+
+    private int code;
+    private String message;
+    @JsonProperty("route")
+    private RouteUnit routeUnit;
+
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/RouteUnit.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/RouteUnit.java
@@ -1,0 +1,13 @@
+package io.fulflix.infra.client.external.naver.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RouteUnit {
+
+    List<Traoptimal> traoptimal;
+
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/Summary.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/Summary.java
@@ -1,0 +1,17 @@
+package io.fulflix.infra.client.external.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Summary {
+
+    private Location start;
+    private Location goal;
+    private int distance;
+    private int duration;
+
+}

--- a/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/Traoptimal.java
+++ b/service/hub-app/src/main/java/io/fulflix/infra/client/external/naver/dto/Traoptimal.java
@@ -1,0 +1,21 @@
+package io.fulflix.infra.client.external.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Traoptimal {
+
+    private Summary summary;
+
+    public int getDistance() {
+        return summary.getDistance();
+    }
+
+    public int getDuration() {
+        return summary.getDuration();
+    }
+}

--- a/service/hub-app/src/test/java/io/fulflix/infra/client/external/naver/NaverDirectionClientTest.java
+++ b/service/hub-app/src/test/java/io/fulflix/infra/client/external/naver/NaverDirectionClientTest.java
@@ -1,0 +1,40 @@
+package io.fulflix.infra.client.external.naver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.fulflix.common.web.base.TestBase;
+import io.fulflix.hub.HubAppApplication;
+import io.fulflix.infra.client.external.naver.dto.RouteResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(classes = HubAppApplication.class, webEnvironment = WebEnvironment.MOCK)
+@DisplayName("Client:NaverDirection")
+class NaverDirectionClientTest extends TestBase {
+
+    private final NaverDirectionClient naverDirectionClient;
+
+    public NaverDirectionClientTest(NaverDirectionClient naverDirectionClient) {
+        this.naverDirectionClient = naverDirectionClient;
+    }
+
+    @Test
+    @DisplayName("네이버 지도 API를 이용한 두 위/경도 사이의 거리 조회")
+    void getDirection() {
+        // Given
+        String startCoordinates = "127.1058342" + ",37.3597078";
+        String endCoordinates = "129.0759853" + ",35.1794697";
+
+        // When
+        RouteResponse actual = naverDirectionClient.getDirection(
+            startCoordinates,
+            endCoordinates
+        );
+
+        // Then
+        assertThat(actual.getCode()).isZero();
+    }
+
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
위/경도 정보와 Naver Map Direction5 API를 이용한 구간 사이의 거리 및 소요 시간 조회를 위해 필요한 FeignClient를 구성합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 Naver Map Direction5 API 호출을 위한 FeignClient 구성
- 📌 Naver Map Direction5 API 응답 파싱을 위한 객체 정의
- 📌 Naver Map Direction5 API 호출 FeignClient TC 작성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

@SpringBootTest를 이용한 통합테스트 환경에서 네이버 Map Direction5 API가 정상적으로 호출됨을 확인 하였습니다.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

Naver NCP Application 생성 시 발급 받은 client-id, client-secret을 application-hub.yml에 작성한 후, 아래 커밋에 작성된 NaverDirectionClient Test Case를 호출하여 동작을 확인할 수 있습니다.
- [Naver Map Direction5 API 호출 TC 작성](https://github.com/fulflix/fulflix/commit/0f1db9a64bebeee4c0f323ba05a703a2515661f0)

Naver Map Direction 5 API 연동을 위한 NaverDirectionClient 구성은 아래 커밋에서 확인할 수 있습니다.
- [Naver Map Direction 5 API 연동을 위한 FeignClient 정의](https://github.com/fulflix/fulflix/commit/a79a6935c52dfb7ce14e65a349224a0567b55428)
## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
