### PR TITLE
fix: remove fulfilx principal to feign client request header interceptor configurations

### DIFF
--- a/core/app-core/src/main/java/io/fulflix/common/app/feign/FeignClientConfig.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/feign/FeignClientConfig.java
@@ -3,9 +3,7 @@ package io.fulflix.common.app.feign;
 import static io.fulflix.common.web.utils.PropertiesCombineUtils.BASE_PACKAGE;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 public class FeignClientConfig {
 
     private static final String FEIGN_CLIENT_PACKAGE = "infra.client";
@@ -13,8 +11,8 @@ public class FeignClientConfig {
         BASE_PACKAGE + "." + FEIGN_CLIENT_PACKAGE;
 
     @Bean
-    public RequestHeaderInterceptor requestHeaderInterceptor() {
-        return new RequestHeaderInterceptor();
+    public FulflixPrincipalRequestHeaderInterceptor requestHeaderInterceptor() {
+        return new FulflixPrincipalRequestHeaderInterceptor();
     }
 
 }

--- a/core/app-core/src/main/java/io/fulflix/common/app/feign/FulflixPrincipalRequestHeaderInterceptor.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/feign/FulflixPrincipalRequestHeaderInterceptor.java
@@ -1,16 +1,19 @@
 package io.fulflix.common.app.feign;
 
 import static io.fulflix.common.app.context.interceptor.UserContextHolderInterceptor.X_USER_ID;
+import static io.fulflix.common.app.context.interceptor.UserRoleContextHolderInterceptor.X_USER_ROLE;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import io.fulflix.common.app.context.holder.UserContextHolder;
+import io.fulflix.common.app.context.holder.UserRoleContextHolder;
 
-public class RequestHeaderInterceptor implements RequestInterceptor {
+public class FulflixPrincipalRequestHeaderInterceptor implements RequestInterceptor {
 
     @Override
     public void apply(RequestTemplate requestTemplate) {
         requestTemplate.header(X_USER_ID, String.valueOf(UserContextHolder.getCurrentUser()));
+        requestTemplate.header(X_USER_ROLE, String.valueOf(UserRoleContextHolder.getCurrentUserRole()));
     }
 
 }


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
@Configuration으로 인해 전역 설정으로 적용된 Fulflix Principal Request Header 설정을 제거합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 FeignClientConfig.java에서 @Configuration 제거
- 📌 FulflixPrincipalRequestHeaderInterceptor.java에 누락된 X-User_Role 설정 부 추가

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
