### PR TITLE
enhance: FulflixPrincipalRequestHeaderInterceptor를 사용하여 관리자 등록한 상품을 현재 로그인한 업체도 수정 가능할 수 있도록 개선

### DIFF
--- a/service/product-app/src/main/java/io/fulflix/infra/client/company/CompanyClient.java
+++ b/service/product-app/src/main/java/io/fulflix/infra/client/company/CompanyClient.java
@@ -1,5 +1,6 @@
 package io.fulflix.infra.client.company;
 
+import io.fulflix.common.app.feign.FulflixPrincipalRequestHeaderInterceptor;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -7,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import static io.fulflix.infra.client.company.CompanyClient.COMPANY_APP_CLIENT;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-@FeignClient(name = COMPANY_APP_CLIENT)
+@FeignClient(name = COMPANY_APP_CLIENT, configuration = FulflixPrincipalRequestHeaderInterceptor.class)
 public interface CompanyClient {
     String COMPANY_APP_CLIENT = "company-app";
     String COMPANY_BY_ID_FOR_ADMIN_URI = "/company/admin/{id}";

--- a/service/product-app/src/main/java/io/fulflix/product/application/strategy/HubCompanyUpdateProduct.java
+++ b/service/product-app/src/main/java/io/fulflix/product/application/strategy/HubCompanyUpdateProduct.java
@@ -23,7 +23,9 @@ public class HubCompanyUpdateProduct implements ProductUpdateStrategy {
         Product product = productRepo.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
-        if (!product.getCreatedBy().equals(currentUser)) {
+        CompanyResponse companyResponse = productValidator.checkCompanyExistsForHub(product.getCompanyId());
+
+        if (!companyResponse.getOwnerId().equals(currentUser)) {
             throw new ProductException(ProductErrorCode.UNAUTHORIZED_ACCESS);
         }
 


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- FeignClient 요청 시 권한이 필요한 api에게 로그인한 사용자의 정보를 추출하여 넘겨줌
- 관리자가 등록한 상품을 현재 로그인한 업체도 수정할 수 있도록 수정

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 FulflixPrincipalRequestHeaderInterceptor 설정 추가

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

- product.http로 client api 권한 별 상품 수정 테스트

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
