### PR TITLE
feat: 주문 전체 조회 및 검색 api

### DIFF
--- a/service/order-app/src/main/java/io/fulflix/order/api/OrderController.java
+++ b/service/order-app/src/main/java/io/fulflix/order/api/OrderController.java
@@ -3,18 +3,16 @@ package io.fulflix.order.api;
 import io.fulflix.common.app.context.annotation.CurrentUser;
 import io.fulflix.common.app.context.annotation.CurrentUserRole;
 import io.fulflix.common.web.principal.Role;
-import io.fulflix.order.api.dto.AdminCreateOrderRequest;
-import io.fulflix.order.api.dto.CreateOrderResponse;
-import io.fulflix.order.api.dto.ReceiverCreateOrderRequest;
-import io.fulflix.order.api.dto.SupplierCreateOrderRequest;
+import io.fulflix.order.api.dto.*;
 import io.fulflix.order.application.OrderFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
@@ -59,5 +57,17 @@ public class OrderController {
     ) {
         CreateOrderResponse createOrderResponse = orderFacade.createReceiverOrder(createOrderRequest, currentUser, role);
         return ResponseEntity.ok(createOrderResponse);
+    }
+
+    // 주문 전체 조회 및 검색 (마스터 관리자, 허브 관리자, 생산 업체, 수령 업체)
+    @GetMapping()
+    public ResponseEntity<Page<OrderDetailResponse>> getAllOrders(
+            @RequestParam(required = false, defaultValue = "0") Integer orderQuantity,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @CurrentUser Long currentUser,
+            @CurrentUserRole Role role
+    ) {
+        Page<OrderDetailResponse> orders = orderFacade.getAllOrders(orderQuantity, pageable, currentUser, role);
+        return ResponseEntity.ok(orders);
     }
 }

--- a/service/order-app/src/main/java/io/fulflix/order/api/dto/OrderDetailResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/order/api/dto/OrderDetailResponse.java
@@ -1,0 +1,39 @@
+package io.fulflix.order.api.dto;
+
+import io.fulflix.order.domain.Order;
+import io.fulflix.order.domain.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderDetailResponse {
+    private Long id;
+    private Long supplierId;
+    private Long receiverId;
+    private Long productId;
+    private Integer orderQuantity;
+    private OrderStatus orderStatus;
+    private boolean isDeleted;
+    private LocalDateTime updatedAt;
+    private Long updatedBy;
+
+    public static OrderDetailResponse fromEntity(Order entity) {
+        return OrderDetailResponse.builder()
+                .id(entity.getId())
+                .supplierId(entity.getSupplierId())
+                .receiverId(entity.getReceiverId())
+                .productId(entity.getProductId())
+                .orderQuantity(entity.getOrderQuantity())
+                .orderStatus(entity.getOrderStatus())
+                .isDeleted(entity.isDeleted())
+                .updatedAt(entity.getUpdatedAt())
+                .updatedBy(entity.getUpdatedBy())
+                .build();
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/OrderFacade.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/OrderFacade.java
@@ -1,18 +1,20 @@
 package io.fulflix.order.application;
 
 import io.fulflix.common.web.principal.Role;
-import io.fulflix.order.api.dto.AdminCreateOrderRequest;
-import io.fulflix.order.api.dto.CreateOrderResponse;
-import io.fulflix.order.api.dto.ReceiverCreateOrderRequest;
-import io.fulflix.order.api.dto.SupplierCreateOrderRequest;
+import io.fulflix.order.api.dto.*;
 import io.fulflix.order.application.strategy.MasterAdminCreateOrder;
 import io.fulflix.order.application.strategy.ReceiverCompanyCreateOrder;
 import io.fulflix.order.application.strategy.SupplierCompanyCreateOrder;
 import io.fulflix.order.exception.OrderErrorCode;
 import io.fulflix.order.exception.OrderException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +22,7 @@ public class OrderFacade {
     private final MasterAdminCreateOrder masterAdminCreateOrder;
     private final SupplierCompanyCreateOrder supplierCompanyCreateOrder;
     private final ReceiverCompanyCreateOrder receiverCompanyCreateOrder;
+    private final List<OrderRetrieveStrategy> orderRetrieveStrategies;
 
     @Transactional
     public CreateOrderResponse createAdminOrder(AdminCreateOrderRequest createOrderRequest, Long currentUser, Role role) {
@@ -46,5 +49,23 @@ public class OrderFacade {
         } else {
             throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
         }
+    }
+
+    // 주문 전체 조회 및 검색
+    public Page<OrderDetailResponse> getAllOrders(
+            Integer orderQuantity,
+            Pageable pageable,
+            Long currentUser,
+            Role role
+    ) {
+        if (pageable.getPageSize() != 10 && pageable.getPageSize() != 30 && pageable.getPageSize() != 50) {
+            pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
+        }
+
+        return orderRetrieveStrategies.stream()
+                .filter(it -> it.isMatched(role))
+                .findAny()
+                .orElseThrow()
+                .retrieveOrders(orderQuantity, pageable, currentUser, role);
     }
 }

--- a/service/order-app/src/main/java/io/fulflix/order/application/OrderRetrieveStrategy.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/OrderRetrieveStrategy.java
@@ -1,0 +1,18 @@
+package io.fulflix.order.application;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderRetrieveStrategy {
+    Page<OrderDetailResponse> retrieveOrders(
+            Integer orderQuantity,
+            Pageable pageable,
+            Long currentUser,
+            Role role
+    );
+
+    boolean isMatched(Role role);
+    boolean hasQuery(Integer orderQuantity);
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubAdminRetrieve.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubAdminRetrieve.java
@@ -1,0 +1,36 @@
+package io.fulflix.order.application.strategy;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import io.fulflix.order.application.OrderRetrieveStrategy;
+import io.fulflix.order.repo.OrderRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubAdminRetrieve implements OrderRetrieveStrategy {
+    private final OrderRepo orderRepo;
+
+    @Override
+    public Page<OrderDetailResponse> retrieveOrders(Integer orderQuantity, Pageable pageable, Long currentUser, Role role) {
+        if (hasQuery(orderQuantity)) {
+            return orderRepo.findByOrderQuantityGreaterThanEqual(orderQuantity, pageable)
+                    .map(OrderDetailResponse::fromEntity);
+        }
+
+        return orderRepo.findAll(pageable).map(OrderDetailResponse::fromEntity);
+    }
+
+    @Override
+    public boolean isMatched(Role role) {
+        return role.isHubAdmin();
+    }
+
+    @Override
+    public boolean hasQuery(Integer orderQuantity) {
+        return orderQuantity != null && orderQuantity > 0;
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubCompanyRetrieve.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubCompanyRetrieve.java
@@ -1,0 +1,36 @@
+package io.fulflix.order.application.strategy;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import io.fulflix.order.application.OrderRetrieveStrategy;
+import io.fulflix.order.repo.OrderRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubCompanyRetrieve implements OrderRetrieveStrategy {
+    private final OrderRepo orderRepo;
+
+    @Override
+    public Page<OrderDetailResponse> retrieveOrders(Integer orderQuantity, Pageable pageable, Long currentUser, Role role) {
+        if (hasQuery(orderQuantity)) {
+            return orderRepo.findByReceiverIdAndOrderQuantityGreaterThanEqual(currentUser, orderQuantity, pageable)
+                    .map(OrderDetailResponse::fromEntity);
+        }
+
+        return orderRepo.findByReceiverId(currentUser, pageable).map(OrderDetailResponse::fromEntity);
+    }
+
+    @Override
+    public boolean isMatched(Role role) {
+        return role.isHubCompany();
+    }
+
+    @Override
+    public boolean hasQuery(Integer orderQuantity) {
+        return orderQuantity != null && orderQuantity > 0;
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminRetrieve.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminRetrieve.java
@@ -1,0 +1,36 @@
+package io.fulflix.order.application.strategy;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import io.fulflix.order.application.OrderRetrieveStrategy;
+import io.fulflix.order.repo.OrderRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MasterAdminRetrieve implements OrderRetrieveStrategy {
+    private final OrderRepo orderRepo;
+
+    @Override
+    public Page<OrderDetailResponse> retrieveOrders(Integer orderQuantity, Pageable pageable, Long currentUser, Role role) {
+        if (hasQuery(orderQuantity)) {
+            return orderRepo.findByOrderQuantityGreaterThanEqual(orderQuantity, pageable)
+                    .map(OrderDetailResponse::fromEntity);
+        }
+
+        return orderRepo.findAll(pageable).map(OrderDetailResponse::fromEntity);
+    }
+
+    @Override
+    public boolean isMatched(Role role) {
+        return role.isMasterAdmin();
+    }
+
+    @Override
+    public boolean hasQuery(Integer orderQuantity) {
+        return orderQuantity != null && orderQuantity > 0;
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/order/repo/OrderRepo.java
+++ b/service/order-app/src/main/java/io/fulflix/order/repo/OrderRepo.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepo extends JpaRepository<Order, Long> {
     Page<Order> findByOrderQuantityGreaterThanEqual(Integer orderQuantity, Pageable pageable);
+    Page<Order> findByReceiverIdAndOrderQuantityGreaterThanEqual(Long currentUser, Integer orderQuantity, Pageable pageable);
+    Page<Order> findByReceiverId(Long currentUser, Pageable pageable);
 }

--- a/service/order-app/src/main/java/io/fulflix/order/repo/OrderRepo.java
+++ b/service/order-app/src/main/java/io/fulflix/order/repo/OrderRepo.java
@@ -1,8 +1,10 @@
 package io.fulflix.order.repo;
 
 import io.fulflix.order.domain.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepo extends JpaRepository<Order, Long> {
-
+    Page<Order> findByOrderQuantityGreaterThanEqual(Integer orderQuantity, Pageable pageable);
 }


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!

- 권한 별 주문 전체 조회 및 검색 api 구현

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 취소된 주문 건까지 보이도록 구현
- 📌 허브 업체는 자신들이 주문한 내역만 볼 수 있도록 구현
- 📌 주문 수량의 검색 조건에 따라 필터링

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

- order.http로 client api 권한 별 주문 전체 조회 및 검색 테스트

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
