### PR TITLE
feat: 주문 단일 조회 api

### DIFF
--- a/docs/client/order-app.http
+++ b/docs/client/order-app.http
@@ -35,3 +35,17 @@ Authorization: Bearer {{access_token}}
   "productId": 4,
   "orderQuantity": 1
 }
+
+###
+
+# @name 주문 전체 조회 및 검색 API (마스터 관리자, 허브 관리자, 생산 업체, 수령 업체)
+GET {{gateway}}/order?orderQuantity=1&page=&size=30&sort=createdAt
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+###
+
+# @name 주문 단일 조회 API (마스터 관리자, 허브 관리자, 생산 업체, 수령 업체)
+GET {{gateway}}/order/7
+Content-Type: application/json
+Authorization: Bearer {{access_token}}

--- a/service/order-app/src/main/java/io/fulflix/order/api/OrderController.java
+++ b/service/order-app/src/main/java/io/fulflix/order/api/OrderController.java
@@ -70,4 +70,15 @@ public class OrderController {
         Page<OrderDetailResponse> orders = orderFacade.getAllOrders(orderQuantity, pageable, currentUser, role);
         return ResponseEntity.ok(orders);
     }
+
+    // 주문 단일 조회 (마스터 관리자, 허브 관리자, 생산 업체, 수령 업체)
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderDetailResponse> getOrder(
+            @PathVariable Long id,
+            @CurrentUser Long currentUser,
+            @CurrentUserRole Role role
+    ) {
+        OrderDetailResponse order = orderFacade.getOrder(id, currentUser, role);
+        return ResponseEntity.ok(order);
+    }
 }

--- a/service/order-app/src/main/java/io/fulflix/order/application/OrderFacade.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/OrderFacade.java
@@ -23,6 +23,7 @@ public class OrderFacade {
     private final SupplierCompanyCreateOrder supplierCompanyCreateOrder;
     private final ReceiverCompanyCreateOrder receiverCompanyCreateOrder;
     private final List<OrderRetrieveStrategy> orderRetrieveStrategies;
+    private final List<OrderRetrieveByIdStrategy> orderRetrieveByIdStrategies;
 
     @Transactional
     public CreateOrderResponse createAdminOrder(AdminCreateOrderRequest createOrderRequest, Long currentUser, Role role) {
@@ -67,5 +68,14 @@ public class OrderFacade {
                 .findAny()
                 .orElseThrow()
                 .retrieveOrders(orderQuantity, pageable, currentUser, role);
+    }
+
+    // 주문 단일 조회
+    public OrderDetailResponse getOrder(Long id, Long currentUser, Role role) {
+        return orderRetrieveByIdStrategies.stream()
+                .filter(it -> it.isMatched(role))
+                .findAny()
+                .orElseThrow()
+                .retrieveOrder(id, currentUser, role);
     }
 }

--- a/service/order-app/src/main/java/io/fulflix/order/application/OrderRetrieveByIdStrategy.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/OrderRetrieveByIdStrategy.java
@@ -1,0 +1,9 @@
+package io.fulflix.order.application;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+
+public interface OrderRetrieveByIdStrategy {
+    OrderDetailResponse retrieveOrder(Long id, Long currentUser, Role role);
+    boolean isMatched(Role role);
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubAdminRetrieveById.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubAdminRetrieveById.java
@@ -1,0 +1,30 @@
+package io.fulflix.order.application.strategy;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import io.fulflix.order.application.OrderRetrieveByIdStrategy;
+import io.fulflix.order.domain.Order;
+import io.fulflix.order.exception.OrderErrorCode;
+import io.fulflix.order.exception.OrderException;
+import io.fulflix.order.repo.OrderRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubAdminRetrieveById implements OrderRetrieveByIdStrategy {
+    private final OrderRepo orderRepo;
+
+    @Override
+    public OrderDetailResponse retrieveOrder(Long id, Long currentUser, Role role) {
+        Order order = orderRepo.findById(id)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return OrderDetailResponse.fromEntity(order);
+    }
+
+    @Override
+    public boolean isMatched(Role role) {
+        return role.isHubAdmin();
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubCompanyRetrieveById.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/HubCompanyRetrieveById.java
@@ -1,0 +1,34 @@
+package io.fulflix.order.application.strategy;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import io.fulflix.order.application.OrderRetrieveByIdStrategy;
+import io.fulflix.order.domain.Order;
+import io.fulflix.order.exception.OrderErrorCode;
+import io.fulflix.order.exception.OrderException;
+import io.fulflix.order.repo.OrderRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubCompanyRetrieveById implements OrderRetrieveByIdStrategy {
+    private final OrderRepo orderRepo;
+
+    @Override
+    public OrderDetailResponse retrieveOrder(Long id, Long currentUser, Role role) {
+        Order order = orderRepo.findById(id)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.getReceiverId().equals(currentUser)) {
+            throw new OrderException(OrderErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return OrderDetailResponse.fromEntity(order);
+    }
+
+    @Override
+    public boolean isMatched(Role role) {
+        return role.isHubCompany();
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminRetrieveById.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminRetrieveById.java
@@ -1,0 +1,30 @@
+package io.fulflix.order.application.strategy;
+
+import io.fulflix.common.web.principal.Role;
+import io.fulflix.order.api.dto.OrderDetailResponse;
+import io.fulflix.order.application.OrderRetrieveByIdStrategy;
+import io.fulflix.order.domain.Order;
+import io.fulflix.order.exception.OrderErrorCode;
+import io.fulflix.order.exception.OrderException;
+import io.fulflix.order.repo.OrderRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MasterAdminRetrieveById implements OrderRetrieveByIdStrategy {
+    private final OrderRepo orderRepo;
+
+    @Override
+    public OrderDetailResponse retrieveOrder(Long id, Long currentUser, Role role) {
+        Order order = orderRepo.findById(id)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return OrderDetailResponse.fromEntity(order);
+    }
+
+    @Override
+    public boolean isMatched(Role role) {
+        return role.isMasterAdmin();
+    }
+}


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- 권한 별 주문 단일 조회 api 구현

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 취소된 주문 건까지 보이도록 구현
- 📌 허브 업체는 자신이 주문한 내역만 볼 수 있도록 구현

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

- order.http로 client api 권한 별 주문 단일 조회 테스트

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
