### PR TITLE
build: swagger for api docs

### DIFF
--- a/core/app-core/build.gradle.kts
+++ b/core/app-core/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(webCore))
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     api("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 
     implementation("com.querydsl:querydsl-jpa:$queryDslVersion:jakarta")
     annotationProcessor("com.querydsl:querydsl-apt:$queryDslVersion:jakarta")

--- a/core/app-core/src/main/java/io/fulflix/common/app/swagger/SwaggerConfig.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/swagger/SwaggerConfig.java
@@ -1,0 +1,16 @@
+package io.fulflix.common.app.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+    info = @Info(
+        title = "Fulflix API",
+        description = "For fulfillment system"
+    )
+)
+@Configuration
+public class SwaggerConfig {
+
+}

--- a/core/app-core/src/main/resources/application.yml
+++ b/core/app-core/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
       - classpath:properties/eureka.yml
       - classpath:properties/actuator.yml
       - classpath:properties/zipkin.yml
+      - classpath:properties/swagger.yml
   profiles:
     active: local
 

--- a/core/app-core/src/main/resources/properties/swagger.yml
+++ b/core/app-core/src/main/resources/properties/swagger.yml
@@ -1,0 +1,3 @@
+springdoc:
+  swagger-ui:
+    path: /docs

--- a/core/web-core/src/main/java/io/fulflix/common/web/exception/event/ThrowsExceptionEventListener.java
+++ b/core/web-core/src/main/java/io/fulflix/common/web/exception/event/ThrowsExceptionEventListener.java
@@ -18,12 +18,13 @@ public class ThrowsExceptionEventListener {
 
         log.error("""
                              \s
-                             REQUEST :[{}, {}]
+                             REQUEST :[{}, {} {}]
                              RESPONSE :[{}, {}]
                              EXCEPTION :[{}, {}]
                              TRACE :[{}]
                 \s""",
             response.getMessage(),
+            response.getMethod(),
             response.getPath(),
             response.getCode(),
             response.getMessage(),


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
각 micro-service의 api 문서 출력을 위한 swagger 의존성을 추가하고, 일관된 접속 정보 제공을 위한 전역 접속 URL 설정을 구성합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 Swagger 의존성 추가 및 Configurations 구성
- 📌 각 micro-service에 일관된 swagger 접속 정보 제공을 위한 환경 설정 구성

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

Swagger를 통해 제공되는 각 micro-service의 API Docs 접속 정보는 아래 Wiki에서 확인할 수 있습니다.

- [Fulflix API Docs](https://github.com/fulflix/fulflix/wiki/API-Docs)

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
