### PR TITLE
fix: remove set created by auditing feilds from company register process

### DIFF
--- a/service/company-app/src/main/java/io/fulflix/company/api/CompanyController.java
+++ b/service/company-app/src/main/java/io/fulflix/company/api/CompanyController.java
@@ -39,7 +39,7 @@ public class CompanyController {
             @CurrentUser Long currentUser,
             @CurrentUserRole Role role
     ) {
-        companyService.registerCompany(registerCompanyRequest, currentUser, role);
+        companyService.registerCompany(registerCompanyRequest, role);
         return created("/company");
     }
 
@@ -51,7 +51,7 @@ public class CompanyController {
             @CurrentUser Long currentUser,
             @CurrentUserRole Role role
     ) {
-        Page<CompanyDetailResponse> companies = companyService.getAllCompaniesForAdmin(query, pageable, currentUser, role);
+        Page<CompanyDetailResponse> companies = companyService.getAllCompaniesForAdmin(query, pageable, role);
         return ResponseEntity.ok(companies);
     }
 
@@ -74,7 +74,7 @@ public class CompanyController {
             @CurrentUser Long currentUser,
             @CurrentUserRole Role role
     ) {
-        CompanyDetailResponse company = companyService.getCompanyByIdForAdmin(id, currentUser, role);
+        CompanyDetailResponse company = companyService.getCompanyByIdForAdmin(id, role);
         return ResponseEntity.ok(company);
     }
 

--- a/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
+++ b/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
@@ -28,20 +28,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class CompanyService {
+
     private final CompanyRepo companyRepo;
     private final HubClient hubClient;
     private final UserClient userClient;
 
     // 업체 등록 (마스터 관리자, 허브 관리자)
     @Transactional
-    public void registerCompany(RegisterCompanyRequest registerCompanyRequest, Long currentUser, Role role) {
+    public void registerCompany(RegisterCompanyRequest registerCompanyRequest, Role role) {
         validateCompanyRegisterProcess(registerCompanyRequest, role);
 
-
         Company company = RegisterCompanyRequest.toEntity(registerCompanyRequest);
-
         company.assignOwnerId(registerCompanyRequest.getOwnerId());
-
         companyRepo.save(company);
     }
 
@@ -54,7 +52,7 @@ public class CompanyService {
     }
 
     // 업체 전체 조회 및 검색 (마스터 관리자)
-    public Page<CompanyDetailResponse> getAllCompaniesForAdmin(String query, Pageable pageable, Long currentUser, Role role) {
+    public Page<CompanyDetailResponse> getAllCompaniesForAdmin(String query, Pageable pageable, Role role) {
         validateMasterAdminAuthority(role);
 
         if (pageable.getPageSize() != 10 && pageable.getPageSize() != 30 && pageable.getPageSize() != 50) {
@@ -74,7 +72,7 @@ public class CompanyService {
     }
 
     // 업체 단일 조회 (마스터 관리자)
-    public CompanyDetailResponse getCompanyByIdForAdmin(Long id, Long currentUser, Role role) {
+    public CompanyDetailResponse getCompanyByIdForAdmin(Long id, Role role) {
         validateMasterAdminAuthority(role);
 
         Company company = findCompanyById(id);
@@ -106,20 +104,6 @@ public class CompanyService {
         }
     }
 
-    // 허브 관리자 권한 확인 예외처리
-    private void validateHubAdminAuthority(Role role) {
-        if (!isHubAdmin(role)) {
-            throw new CompanyException(CompanyErrorCode.UNAUTHORIZED_ACCESS);
-        }
-    }
-
-    // 허브 업체 권한 확인 예외처리
-    private void validateHubCompanyAuthority(Role role) {
-        if (!isHubCompany(role)) {
-            throw new CompanyException(CompanyErrorCode.UNAUTHORIZED_ACCESS);
-        }
-    }
-
     // 마스터 관리자 & 허브 관리자 확인 예외처리
     private void validateAdminAuthority(Role role) {
         if (!isAdmin(role)) {
@@ -132,19 +116,9 @@ public class CompanyService {
         return role.isMasterAdmin();
     }
 
-    // 허브 관리자 권한 확인
-    private boolean isHubAdmin(Role role) {
-        return role.isHubAdmin();
-    }
-
     // 마스터 관리자 & 허브 관리자 권한 확인
     private boolean isAdmin(Role role) {
         return role.isMasterAdmin() || role.isHubAdmin();
-    }
-
-    // 허브 업체 권한 확인
-    private boolean isHubCompany(Role role) {
-        return role.isHubCompany();
     }
 
     // 업체명 중복 확인
@@ -157,6 +131,7 @@ public class CompanyService {
     // 삭제 여부와 상관없이 모든 업체 존재 확인 (관리자용)
     private Company findCompanyById(Long id) {
         return companyRepo.findById(id)
-                .orElseThrow(() -> new CompanyException(CompanyErrorCode.COMPANY_NOT_FOUND));
+            .orElseThrow(() -> new CompanyException(CompanyErrorCode.COMPANY_NOT_FOUND));
     }
+
 }

--- a/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
+++ b/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
@@ -59,16 +59,16 @@ public class CompanyService {
             pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
         }
 
-        // 마스터 관리자 : 삭제된 업체까지 모두 조회
-        Page<Company> companies;
-
-        if (query != null && !query.isEmpty()) {
-            companies = companyRepo.findByCompanyNameContaining(query, pageable); // 검색어 있으면
-        } else {
-            companies = companyRepo.findAll(pageable); // 검색어 없으면
+        if (hasSearchQuery(query)) {
+            return companyRepo.findByCompanyNameContaining(query, pageable)
+                .map(CompanyDetailResponse::fromEntity);
         }
+        return companyRepo.findAll(pageable)
+            .map(CompanyDetailResponse::fromEntity);
+    }
 
-        return companies.map(CompanyDetailResponse::fromEntity);
+    private static boolean hasSearchQuery(String query) {
+        return query != null && !query.isEmpty();
     }
 
     // 업체 단일 조회 (마스터 관리자)
@@ -123,7 +123,7 @@ public class CompanyService {
 
     // 업체명 중복 확인
     private void checkCompanyDuplication(String companyName) {
-        if (companyRepo.findByCompanyName(companyName).isPresent()) {
+        if (companyRepo.existsByCompanyName(companyName)) {
             throw new CompanyException(CompanyErrorCode.DUPLICATE_COMPANY_NAME);
         }
     }

--- a/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
+++ b/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,20 +33,24 @@ public class CompanyService {
     private final UserClient userClient;
 
     // 업체 등록 (마스터 관리자, 허브 관리자)
+    @Transactional
     public void registerCompany(RegisterCompanyRequest registerCompanyRequest, Long currentUser, Role role) {
-        validateAdminAuthority(role);
+        validateCompanyRegisterProcess(registerCompanyRequest, role);
 
-        checkHubExists(registerCompanyRequest.getHubId());
-        checkUserExists(registerCompanyRequest.getOwnerId());
-
-        checkCompanyDuplication(registerCompanyRequest.getCompanyName());
 
         Company company = RegisterCompanyRequest.toEntity(registerCompanyRequest);
 
         company.assignOwnerId(registerCompanyRequest.getOwnerId());
-        company.applyCompanyCreated(currentUser);
 
         companyRepo.save(company);
+    }
+
+    private void validateCompanyRegisterProcess(RegisterCompanyRequest registerCompanyRequest, Role role) {
+        validateAdminAuthority(role);
+
+        checkHubExists(registerCompanyRequest.getHubId());
+        checkUserExists(registerCompanyRequest.getOwnerId());
+        checkCompanyDuplication(registerCompanyRequest.getCompanyName());
     }
 
     // 업체 전체 조회 및 검색 (마스터 관리자)

--- a/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
+++ b/service/company-app/src/main/java/io/fulflix/company/application/CompanyService.java
@@ -55,6 +55,7 @@ public class CompanyService {
     public Page<CompanyDetailResponse> getAllCompaniesForAdmin(String query, Pageable pageable, Role role) {
         validateMasterAdminAuthority(role);
 
+        // TODO CustomPageableHandlerMethodArgumentResolver를 이용한 기본 페이지 사이즈 요청 값 고정 처리
         if (pageable.getPageSize() != 10 && pageable.getPageSize() != 30 && pageable.getPageSize() != 50) {
             pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
         }

--- a/service/company-app/src/main/java/io/fulflix/company/repo/CompanyRepo.java
+++ b/service/company-app/src/main/java/io/fulflix/company/repo/CompanyRepo.java
@@ -29,4 +29,7 @@ public interface CompanyRepo extends JpaRepository<Company, Long> {
 
     // 허브 업체용 단일 조회
     Optional<Company> findByIdAndOwnerIdAndIsDeletedFalse(Long id, Long currentUser);
+
+    boolean existsByCompanyName(String companyName);
+
 }


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
Company Entity의 Auditing 적용을 위한 EntityListener 설정 객체를 CompanyAuditable에서 Auditable로 변경함에 따라 Company 등록 시 CreatedBy를 명시적으로 설정하는 코드를 제거 합니다.

그 외 코드 가독성을 위해 사용하지 않는 파라미터와 메서드를 제거하고, 일부 표현을 개선 합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 [Company Entity의 Auditing 적용 객체 변경에 따른 Company 등록 시 CreatedBy 설정 부 제거](https://github.com/fulflix/fulflix/commit/78777610453663d73c3879229c0a9033deefa5f9)
- 📌 [미 사용 파라미터 및 메서드 제거](https://github.com/fulflix/fulflix/commit/a6cfc706426389f12fe3d72259882f54441faf49)
- 📌 [가독성을 위한 코드 표현 개선](https://github.com/fulflix/fulflix/commit/d5d58dea4613b8cd66f75e46c9103b9eb0eae6c9)

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
