### PR TITLE
feat: re-adjust pageable using custom argument resolver

### DIFF
--- a/core/app-core/src/main/java/io/fulflix/common/app/context/config/WebConfig.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/context/config/WebConfig.java
@@ -2,18 +2,22 @@ package io.fulflix.common.app.context.config;
 
 import io.fulflix.common.app.context.annotation.resolver.CurrentUserArgumentResolver;
 import io.fulflix.common.app.context.annotation.resolver.CurrentUserRoleArgumentResolver;
+import io.fulflix.common.app.jpa.pageable.FixedPageSizeHandlerMethodArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class CurrentUserResolverConfig implements WebMvcConfigurer {
+public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new CurrentUserArgumentResolver());
         resolvers.add(new CurrentUserRoleArgumentResolver());
+        SortHandlerMethodArgumentResolver sortResolver = new SortHandlerMethodArgumentResolver();
+        resolvers.add(new FixedPageSizeHandlerMethodArgumentResolver(sortResolver));
     }
 
 }

--- a/core/app-core/src/main/java/io/fulflix/common/app/context/config/WebConfig.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/context/config/WebConfig.java
@@ -2,7 +2,7 @@ package io.fulflix.common.app.context.config;
 
 import io.fulflix.common.app.context.annotation.resolver.CurrentUserArgumentResolver;
 import io.fulflix.common.app.context.annotation.resolver.CurrentUserRoleArgumentResolver;
-import io.fulflix.common.app.jpa.pageable.FixedPageSizeHandlerMethodArgumentResolver;
+import io.fulflix.common.app.jpa.pageable.FixedPageableHandlerMethodArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.web.SortHandlerMethodArgumentResolver;
@@ -17,7 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
         resolvers.add(new CurrentUserArgumentResolver());
         resolvers.add(new CurrentUserRoleArgumentResolver());
         SortHandlerMethodArgumentResolver sortResolver = new SortHandlerMethodArgumentResolver();
-        resolvers.add(new FixedPageSizeHandlerMethodArgumentResolver(sortResolver));
+        resolvers.add(new FixedPageableHandlerMethodArgumentResolver(sortResolver));
     }
 
 }

--- a/core/app-core/src/main/java/io/fulflix/common/app/jpa/pageable/FixedPageSizeHandlerMethodArgumentResolver.java
+++ b/core/app-core/src/main/java/io/fulflix/common/app/jpa/pageable/FixedPageSizeHandlerMethodArgumentResolver.java
@@ -1,0 +1,46 @@
+package io.fulflix.common.app.jpa.pageable;
+
+import java.util.List;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class FixedPageSizeHandlerMethodArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+    private static final int FIXED_PAGE_SIZE = 10;
+    private static final List<Integer> SUPPORTED_PAGE_SIZES = List.of(10, 30, 50);
+
+    public FixedPageSizeHandlerMethodArgumentResolver(SortHandlerMethodArgumentResolver sortResolver) {
+        super(sortResolver);
+    }
+
+    @Override
+    public Pageable resolveArgument(MethodParameter methodParameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) {
+        Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        int reAdjustedPageSize = adjustPageSize(pageable);
+
+        return PageRequest.of(pageable.getPageNumber(), reAdjustedPageSize, pageable.getSort());
+    }
+
+    private int adjustPageSize(Pageable pageable) {
+        if (isNotSupportedPageSize(pageable)) {
+            return FIXED_PAGE_SIZE;
+        }
+        return pageable.getPageSize();
+    }
+
+    private boolean isNotSupportedPageSize(Pageable pageable) {
+        return !SUPPORTED_PAGE_SIZES.contains(pageable.getPageSize());
+    }
+
+}

--- a/docs/client/user-app.http
+++ b/docs/client/user-app.http
@@ -12,9 +12,8 @@ Authorization: Bearer {{access_token}}
 
 ###
 
-
-## 회원 목록 조회 API
-GET {{gateway}}/user
+# @name 회원 목록 조회 API
+GET {{gateway}}/user?page=1&size=10&sort=createdAt,asc
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
요구사항에 따라 요청 페이지 크기가 10/30/50이 아닌 경우 10으로 고정하는 CustomArgumentResolver를 구성합니다.

페이지 크기를 10/30/50이 아닌 경우 10으로 고정함에 따라 시작 페이지를 0이 아닌 1부터 시작할 수 있도록 페이지 번호 재 조정 처리를 포함합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 [10/30/50 외의 page size 요청 시, 기본 page size 10 고정을 위한 Custom Argument Resolver 구현](https://github.com/fulflix/fulflix/commit/156c8d653d5b2efa593e1ca11f83f9e8a5b7c805)
- 📌 [시작 페이지를 1부터 고정하기 위한 page number 재 조정 처리 추가](https://github.com/fulflix/fulflix/commit/9c00f5c174c58f97cb925ea81fa203622452c1cb)

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

user-app의 회원 목록 조회 API 호출을 통해 요청 페이지 크기가 10/30/50이 아닌 경우 10으로 고정됨을 확인하였습니다. 

또한, 시작 페이지가 0 또는 1로 재 조정 되었음을 확인 하였습니다.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

@PageableDefault 어노테이션을 사용해서 페이징 처리 시, CustomArgumentResolver에 의해 요청 페이지 크기가 10/30/50 으로 재 조정 되므로 Pageable 객체의 PageSize가 10/30/50이 아닌 경우 10으로 고정하는 로직은 제거가 필요합니다.

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---

close #68 