### PR TITLE
feat: 주문 생성 시, 배송 요청 생성 api 연결

### DIFF
--- a/core/web-core/src/main/java/io/fulflix/core/web/exception/response/GlobalErrorResponse.java
+++ b/core/web-core/src/main/java/io/fulflix/core/web/exception/response/GlobalErrorResponse.java
@@ -1,14 +1,17 @@
 package io.fulflix.core.web.exception.response;
 
-import static lombok.AccessLevel.PROTECTED;
-
 import io.fulflix.core.web.exception.BusinessException;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor(access = PROTECTED)
 public sealed class GlobalErrorResponse permits MethodArgumentNotValidErrorResponse {
 

--- a/docs/client/company-app-user.http
+++ b/docs/client/company-app-user.http
@@ -1,4 +1,4 @@
-## MASTER_AMDIN 회원가입 API
+# @name MASTER_AMDIN 회원가입 API
 POST {{gateway}}/auth/sign-up
 Content-Type: application/json
 
@@ -11,7 +11,7 @@ Content-Type: application/json
 
 ###
 
-## MASTER_AMDIN 로그인 API
+# @name MASTER_AMDIN 로그인 API
 POST {{gateway}}/auth/sign-in
 Content-Type: application/json
 
@@ -25,7 +25,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_AMDIN(경기 북부 센터) 회원가입 API
+# @name HUB_AMDIN(경기 북부 센터) 회원가입 API
 POST {{gateway}}/auth/sign-up
 Content-Type: application/json
 
@@ -38,7 +38,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_AMDIN(경기 북부 센터) 로그인 API
+# @name HUB_AMDIN(경기 북부 센터) 로그인 API
 POST {{gateway}}/auth/sign-in
 Content-Type: application/json
 
@@ -52,7 +52,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_AMDIN(부산광역시 센터) 회원가입 API
+# @name HUB_AMDIN(부산광역시 센터) 회원가입 API
 POST {{gateway}}/auth/sign-up
 Content-Type: application/json
 
@@ -65,7 +65,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_AMDIN(부산광역시 센터) 로그인 API
+# @name HUB_AMDIN(부산광역시 센터) 로그인 API
 POST {{gateway}}/auth/sign-in
 Content-Type: application/json
 
@@ -79,7 +79,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_COMPANY(생산 업체) 회원가입 API
+# @name HUB_COMPANY(생산 업체) 회원가입 API
 POST {{gateway}}/auth/sign-up
 Content-Type: application/json
 
@@ -92,7 +92,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_COMPANY(생산 업체) 로그인 API
+# @name HUB_COMPANY(생산 업체) 로그인 API
 POST {{gateway}}/auth/sign-in
 Content-Type: application/json
 
@@ -106,7 +106,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_COMPANY(수령 업체) 회원가입 API
+# @name HUB_COMPANY(수령 업체) 회원가입 API
 POST {{gateway}}/auth/sign-up
 Content-Type: application/json
 
@@ -119,7 +119,7 @@ Content-Type: application/json
 
 ###
 
-## HUB_COMPANY(수령 업체) 로그인 API
+# @name HUB_COMPANY(수령 업체) 로그인 API
 POST {{gateway}}/auth/sign-in
 Content-Type: application/json
 

--- a/docs/client/company-app.http
+++ b/docs/client/company-app.http
@@ -1,4 +1,4 @@
-## 생산 업체 등록 API
+# @name 생산 업체 등록 API
 POST {{gateway}}/company
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
@@ -13,7 +13,7 @@ Authorization: Bearer {{access_token}}
 
 ###
 
-## 수령 업체 등록 API
+# @name 수령 업체 등록 API
 POST {{gateway}}/company
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
@@ -28,35 +28,35 @@ Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 전체 조회 및 검색 API (마스터 관리자용)
+# @name 업체 전체 조회 및 검색 API (마스터 관리자용)
 GET http://localhost:8088/company/admin?query=생산&page=&size=20&sort=createdAt,asc
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 전체 조회 및 검색 API (허브 관리자, 허브 업체용)
+# @name 업체 전체 조회 및 검색 API (허브 관리자, 허브 업체용)
 GET http://localhost:8088/company/hub?query=플라스틱&page=&size=20&sort=
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 단일 조회 API (마스터 관리자용)
+# @name 업체 단일 조회 API (마스터 관리자용)
 GET http://localhost:8088/company/admin/1
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 단일 조회 API (허브 관리자, 허브 업체용)
+# @name 업체 단일 조회 API (허브 관리자, 허브 업체용)
 GET http://localhost:8088/company/hub/1
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 수정 API (hubId)
+# @name 업체 수정 API (hubId)
 PUT http://localhost:8088/company/2
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
@@ -67,7 +67,7 @@ Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 수정 API (companyName or companyAddress)
+# @name 업체 수정 API (companyName or companyAddress)
 PUT http://localhost:8088/company/2
 Content-Type: application/json
 Authorization: Bearer {{access_token}}
@@ -78,7 +78,7 @@ Authorization: Bearer {{access_token}}
 
 ###
 
-## 업체 삭제 API
+# @name 업체 삭제 API
 DELETE {{gateway}}/company/1
 Content-Type: application/json
 Authorization: Bearer {{access_token}}

--- a/docs/client/order-app.http
+++ b/docs/client/order-app.http
@@ -5,9 +5,15 @@ Authorization: Bearer {{access_token}}
 
 {
   "supplierId": 1,
-  "receiverId": 3,
-  "productId": 4,
-  "orderQuantity": 1
+  "receiverId": 2,
+  "productId": 2,
+  "orderQuantity": 1,
+  "deliveryRequest": {
+    "departureHubId": 2,
+    "arrivalHubId": 4,
+    "recipient": "이유리",
+    "recipientSlackId": "yuri.slack"
+  }
 }
 
 ###
@@ -18,9 +24,9 @@ Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 {
-  "receiverId": 3,
-  "productId": 4,
-  "orderQuantity": 1
+  "receiverId": 4,
+  "productId": 1,
+  "orderQuantity": 30
 }
 
 ###
@@ -31,9 +37,9 @@ Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 {
-  "supplierId": 4,
-  "productId": 4,
-  "orderQuantity": 1
+  "supplierId": 1,
+  "productId": 1,
+  "orderQuantity": 30
 }
 
 ###

--- a/docs/client/product-app.http
+++ b/docs/client/product-app.http
@@ -4,9 +4,33 @@ Content-Type: application/json
 Authorization: Bearer {{access_token}}
 
 {
-  "companyId": 2,
-  "productName": "합성 섬유",
-  "stockQuantity": 10
+  "companyId": 1,
+  "productName": "플라스틱 바구니 외각",
+  "stockQuantity": 100
+}
+
+###
+
+POST {{gateway}}/product
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "companyId": 1,
+  "productName": "플라스틱 손잡이",
+  "stockQuantity": 100
+}
+
+###
+
+POST {{gateway}}/product
+Content-Type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "companyId": 1,
+  "productName": "플라스틱 바퀴",
+  "stockQuantity": 100
 }
 
 ###

--- a/service/delivery-app/src/main/java/io/fulflix/infra/client/dto/HubResponseDto.java
+++ b/service/delivery-app/src/main/java/io/fulflix/infra/client/dto/HubResponseDto.java
@@ -1,14 +1,21 @@
 package io.fulflix.infra.client.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonDeserialize(builder = HubResponseDto.HubResponseDtoBuilder.class)
 public class HubResponseDto {
     private Long id;
     private String name;
     private String address;
     private Double latitude;
     private Double longitude;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class HubResponseDtoBuilder {
+    }
 }

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryClient.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryClient.java
@@ -3,6 +3,7 @@ package io.fulflix.infra.client.delivery;
 import io.fulflix.core.app.feign.FeignClientErrorDecoder;
 import io.fulflix.core.app.feign.FulflixPrincipalRequestHeaderInterceptor;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -15,6 +16,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 public interface DeliveryClient extends DeliveryService {
     String DELIVERY_APP_CLIENT = "delivery-app";
     String CREATE_DELIVERY_URI = "/delivery";
+    String CREATE_DELIVERY_ROUTE_URI = "/delivery-route/{deliveryId}";
 
     // 배송 생성 API
     @PostMapping(
@@ -22,5 +24,13 @@ public interface DeliveryClient extends DeliveryService {
             consumes = APPLICATION_JSON_VALUE,
             produces = APPLICATION_JSON_VALUE
     )
-    void createDelivery(@RequestBody DeliveryRequest deliveryRequest);
+    DeliveryResponse createDelivery(@RequestBody DeliveryRequest deliveryRequest);
+
+    // 배송 경로 생성 API
+    @PostMapping(
+            path = CREATE_DELIVERY_ROUTE_URI,
+            consumes = APPLICATION_JSON_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
+    void createDeliveryRoute(@PathVariable Long deliveryId);
 }

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryClient.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryClient.java
@@ -1,0 +1,26 @@
+package io.fulflix.infra.client.delivery;
+
+import io.fulflix.core.app.feign.FeignClientErrorDecoder;
+import io.fulflix.core.app.feign.FulflixPrincipalRequestHeaderInterceptor;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@FeignClient(name = DeliveryClient.DELIVERY_APP_CLIENT, configuration = {
+        FulflixPrincipalRequestHeaderInterceptor.class,
+        FeignClientErrorDecoder.class
+})
+public interface DeliveryClient extends DeliveryService {
+    String DELIVERY_APP_CLIENT = "delivery-app";
+    String CREATE_DELIVERY_URI = "/delivery";
+
+    // 배송 생성 API
+    @PostMapping(
+            path = CREATE_DELIVERY_URI,
+            consumes = APPLICATION_JSON_VALUE,
+            produces = APPLICATION_JSON_VALUE
+    )
+    void createDelivery(@RequestBody DeliveryRequest deliveryRequest);
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryRequest.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryRequest.java
@@ -1,0 +1,33 @@
+package io.fulflix.infra.client.delivery;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.*;
+
+@Getter
+@Builder
+@JsonDeserialize(builder = DeliveryRequest.DeliveryRequestBuilder.class)
+public class DeliveryRequest {
+    private Long orderId;
+    private Long departureHubId;
+    private Long arrivalHubId;
+    private String deliveryAddress;
+    private String recipient;
+    private String recipientSlackId;
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class DeliveryRequestBuilder {
+    }
+
+    @Override
+    public String toString() {
+        return "DeliveryRequest{" +
+                "orderId=" + orderId +
+                ", departureHubId=" + departureHubId +
+                ", arrivalHubId=" + arrivalHubId +
+                ", deliveryAddress='" + deliveryAddress + '\'' +
+                ", recipient='" + recipient + '\'' +
+                ", recipientSlackId='" + recipientSlackId + '\'' +
+                '}';
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryResponse.java
@@ -1,0 +1,21 @@
+package io.fulflix.infra.client.delivery;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeliveryResponse {
+    private Long id;
+    private Long orderId;
+    private Long departureHubId;
+    private Long arrivalHubId;
+    private String deliveryAddress;
+    private String recipient;
+    private String recipientSlackId;
+    private List<DeliveryRouteResponse> deliveryRouteResponseList;
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryRouteResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryRouteResponse.java
@@ -1,0 +1,17 @@
+package io.fulflix.infra.client.delivery;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeliveryRouteResponse {
+    private Long id;
+    private Long deliveryId;
+    private Integer sequence;
+    private Long departureHubId;
+    private Long arrivalHubId;
+    private Double estimatedDistance;
+    private Long estimatedDuration;
+    private String status;
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryService.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryService.java
@@ -1,5 +1,6 @@
 package io.fulflix.infra.client.delivery;
 
 public interface DeliveryService {
-    void createDelivery(DeliveryRequest deliveryRequest);
+    DeliveryResponse createDelivery(DeliveryRequest deliveryRequest);
+    void createDeliveryRoute(Long deliveryId);
 }

--- a/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryService.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/delivery/DeliveryService.java
@@ -1,0 +1,5 @@
+package io.fulflix.infra.client.delivery;
+
+public interface DeliveryService {
+    void createDelivery(DeliveryRequest deliveryRequest);
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/exception/HubErrorCode.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/exception/HubErrorCode.java
@@ -1,0 +1,17 @@
+package io.fulflix.infra.client.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HubErrorCode {
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 허브를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    HubErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/exception/HubException.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/exception/HubException.java
@@ -1,0 +1,19 @@
+package io.fulflix.infra.client.exception;
+
+import io.fulflix.core.web.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class HubException extends BusinessException {
+    private final HubErrorCode errorCode;
+
+    public HubException(HubErrorCode code) {
+        super(code.getStatus(), code.name(), code.getMessage());
+        errorCode = code;
+    }
+
+    public HubException(HubErrorCode code, Object... args) {
+        super(code.getStatus(), code.name(), code.getMessage(), args);
+        this.errorCode = code;
+    }
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/hub/HubClient.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/hub/HubClient.java
@@ -1,8 +1,7 @@
-package io.fulflix.infra.client;
+package io.fulflix.infra.client.hub;
 
 import io.fulflix.core.app.feign.FeignClientErrorDecoder;
 import io.fulflix.core.app.feign.FulflixPrincipalRequestHeaderInterceptor;
-import io.fulflix.infra.client.dto.HubResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,14 +12,15 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
         FulflixPrincipalRequestHeaderInterceptor.class,
         FeignClientErrorDecoder.class
 })
-public interface HubClient {
+public interface HubClient extends HubService {
     String HUB_APP_CLIENT = "hub-app";
-    String GET_HUB_DETAIL_URI = "/hub/{hubId}";
+    String GET_HUB_BY_ID_URI = "/hub/{hubId}";
 
+    // 허브 조회 API
     @GetMapping(
-            path = GET_HUB_DETAIL_URI,
+            path = GET_HUB_BY_ID_URI,
             consumes = APPLICATION_JSON_VALUE,
             produces = APPLICATION_JSON_VALUE
     )
-    HubResponseDto getHub(@PathVariable Long hubId);
+    HubResponse getHubById(@PathVariable Long hubId);
 }

--- a/service/order-app/src/main/java/io/fulflix/infra/client/hub/HubResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/hub/HubResponse.java
@@ -1,0 +1,14 @@
+package io.fulflix.infra.client.hub;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HubResponse {
+    private Long id;
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/hub/HubService.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/hub/HubService.java
@@ -1,0 +1,5 @@
+package io.fulflix.infra.client.hub;
+
+public interface HubService {
+    HubResponse getHubById(Long hubId);
+}

--- a/service/order-app/src/main/java/io/fulflix/infra/client/product/ProductDetailResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/product/ProductDetailResponse.java
@@ -11,7 +11,7 @@ public class ProductDetailResponse {
     private Long id;
     private Long hubId;
     private Long companyId;
-    private String ProductName;
+    private String productName;
     private Integer stockQuantity;
     private boolean isDeleted;
     private Long updatedBy;

--- a/service/order-app/src/main/java/io/fulflix/order/api/dto/AdminCreateOrderRequest.java
+++ b/service/order-app/src/main/java/io/fulflix/order/api/dto/AdminCreateOrderRequest.java
@@ -1,5 +1,6 @@
 package io.fulflix.order.api.dto;
 
+import io.fulflix.infra.client.delivery.DeliveryRequest;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -22,4 +23,7 @@ public class AdminCreateOrderRequest {
     @NotNull(message = "주문 수량을 입력해 주세요.")
     @Min(value = 1, message = "최소 주문 수량은 1개입니다.")
     private Integer orderQuantity;
+
+    @NotNull(message = "배송 정보를 입력해 주세요.")
+    private DeliveryRequest deliveryRequest;
 }

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminCreateOrder.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminCreateOrder.java
@@ -3,6 +3,7 @@ package io.fulflix.order.application.strategy;
 import io.fulflix.core.web.principal.Role;
 import io.fulflix.infra.client.delivery.DeliveryClient;
 import io.fulflix.infra.client.delivery.DeliveryRequest;
+import io.fulflix.infra.client.delivery.DeliveryResponse;
 import io.fulflix.infra.client.exception.HubErrorCode;
 import io.fulflix.infra.client.exception.HubException;
 import io.fulflix.infra.client.hub.HubClient;
@@ -77,7 +78,11 @@ public class MasterAdminCreateOrder implements OrderCreateStrategy {
                     .build();
 
             log.info("배송 요청 데이터: {}", deliveryRequest);
-            deliveryClient.createDelivery(deliveryRequest);  // 배송 생성 API 호출
+            DeliveryResponse deliveryResponse = deliveryClient.createDelivery(deliveryRequest);  // 배송 생성 API 호출
+            Long deliveryId = deliveryResponse.getId(); // 배송 Id
+
+            deliveryClient.createDeliveryRoute(deliveryId);  // 배송 경로 생성 API 호출
+            log.info("배송 경로 생성 요청 완료 - 배송 ID: {}", deliveryId);
         }
 
         // 주문 상태 반환 (재고O - SUCCESS / 재고X - FAIL)

--- a/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminCreateOrder.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/strategy/MasterAdminCreateOrder.java
@@ -1,6 +1,12 @@
 package io.fulflix.order.application.strategy;
 
 import io.fulflix.core.web.principal.Role;
+import io.fulflix.infra.client.delivery.DeliveryClient;
+import io.fulflix.infra.client.delivery.DeliveryRequest;
+import io.fulflix.infra.client.exception.HubErrorCode;
+import io.fulflix.infra.client.exception.HubException;
+import io.fulflix.infra.client.hub.HubClient;
+import io.fulflix.infra.client.hub.HubResponse;
 import io.fulflix.infra.client.product.ProductDetailResponse;
 import io.fulflix.order.api.dto.AdminCreateOrderRequest;
 import io.fulflix.order.api.dto.CreateOrderResponse;
@@ -14,6 +20,7 @@ import io.fulflix.order.repo.OrderRepo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -21,14 +28,30 @@ import org.springframework.stereotype.Component;
 public class MasterAdminCreateOrder implements OrderCreateStrategy {
     private final OrderRepo orderRepo;
     private final OrderValidator orderValidator;
+    private final DeliveryClient deliveryClient;
+    private final HubClient hubClient;
 
     @Override
+    @Transactional
     public CreateOrderResponse AdminCreateOrder(AdminCreateOrderRequest createOrderRequest, Long currentUser, Role role) {
+        // 상품, 업체 유효성 검사
         ProductDetailResponse productResponse = orderValidator.checkProductExistForAdmin(createOrderRequest.getProductId());
         orderValidator.checkCompanyExistForAdmin(createOrderRequest.getSupplierId(), "SUPPLIER");
         orderValidator.checkCompanyExistForAdmin(createOrderRequest.getReceiverId(), "RECEIVER");
         OrderStatus orderStatus = orderValidator.validateStockAvailabilityForAdmin(productResponse, createOrderRequest.getOrderQuantity());
 
+        // 출발/도착 허브 유효성 검사
+        HubResponse departureHub = hubClient.getHubById(createOrderRequest.getDeliveryRequest().getDepartureHubId());
+        if (departureHub == null || departureHub.getId() == null) {
+            throw new HubException(HubErrorCode.HUB_NOT_FOUND);
+        }
+
+        HubResponse arrivalHub = hubClient.getHubById(createOrderRequest.getDeliveryRequest().getArrivalHubId());
+        if (arrivalHub == null || arrivalHub.getId() == null) {
+            throw new HubException(HubErrorCode.HUB_NOT_FOUND);
+        }
+
+        // 주문 생성
         Order order = Order.builder()
                 .supplierId(productResponse.getCompanyId())
                 .receiverId(createOrderRequest.getReceiverId())
@@ -37,12 +60,27 @@ public class MasterAdminCreateOrder implements OrderCreateStrategy {
                 .orderStatus(orderStatus)
                 .build();
 
-        if (orderStatus == OrderStatus.SUCCESS) {
-            orderValidator.reduceStock(createOrderRequest.getProductId(), createOrderRequest.getOrderQuantity());
-        }
-
         orderRepo.save(order);
 
+        if (orderStatus == OrderStatus.SUCCESS) {
+            // 재고 감소
+            orderValidator.reduceStock(createOrderRequest.getProductId(), createOrderRequest.getOrderQuantity());
+
+            // 배송 생성
+            DeliveryRequest deliveryRequest = DeliveryRequest.builder()
+                    .orderId(order.getId())  // 주문 ID
+                    .departureHubId(departureHub.getId())  // 출발 허브 ID
+                    .arrivalHubId(arrivalHub.getId())  // 도착 허브 ID
+                    .deliveryAddress(arrivalHub.getAddress())  // 배송 주소
+                    .recipient(createOrderRequest.getDeliveryRequest().getRecipient())  // 수취인
+                    .recipientSlackId(createOrderRequest.getDeliveryRequest().getRecipientSlackId())  // 수취인 Slack ID
+                    .build();
+
+            log.info("배송 요청 데이터: {}", deliveryRequest);
+            deliveryClient.createDelivery(deliveryRequest);  // 배송 생성 API 호출
+        }
+
+        // 주문 상태 반환 (재고O - SUCCESS / 재고X - FAIL)
         return new CreateOrderResponse(orderStatus);
     }
 

--- a/service/order-app/src/main/java/io/fulflix/order/application/validator/OrderValidator.java
+++ b/service/order-app/src/main/java/io/fulflix/order/application/validator/OrderValidator.java
@@ -25,6 +25,7 @@ public class OrderValidator {
     private final CompanyClient companyClient;
 
     public ProductDetailResponse checkProductExistForAdmin(Long productId) {
+        log.info("상품 존재 확인 - productId: {}", productId);
         try {
             ProductDetailResponse productResponse = productClient.getProductForAdminById(productId);
             if (productResponse == null || productResponse.isDeleted()) {
@@ -32,6 +33,7 @@ public class OrderValidator {
             }
             return productResponse;
         } catch (FeignException e) {
+            log.error("FeignClient 호출 실패 - productId: {}", productId, e);
             throw new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND);
         }
     }
@@ -49,6 +51,7 @@ public class OrderValidator {
     }
 
     public void checkCompanyExistForAdmin(Long companyId, String companyType) {
+        log.info("업체 존재 확인 - productId: {} {}", companyId, companyType);
         try {
             CompanyDetailResponse companyResponse = companyClient.getCompanyForAdminById(companyId);
             if (companyResponse == null) {
@@ -58,6 +61,7 @@ public class OrderValidator {
                 throw new CompanyException(CompanyErrorCode.COMPANY_NOT_FOUND);
             }
         } catch (FeignException e) {
+            log.error("FeignClient 호출 실패 - companyId: {}", companyId, e);
             throw new CompanyException(CompanyErrorCode.COMPANY_NOT_FOUND);
         }
     }
@@ -77,6 +81,7 @@ public class OrderValidator {
     }
 
     public OrderStatus validateStockAvailabilityForAdmin(ProductDetailResponse productResponse, int orderQuantity) {
+        log.info("상품 재고: {}, 주문 수량: {}", productResponse.getStockQuantity(), orderQuantity);
         if (productResponse.getStockQuantity() >= orderQuantity) {
             return OrderStatus.SUCCESS;
         } else {
@@ -93,10 +98,12 @@ public class OrderValidator {
     }
 
     public void reduceStock(Long productId, int orderQuantity) {
+        log.info("재고 감소 요청 - 상품 ID: {}, 감소량: {}", productId, orderQuantity);
         try {
             ReduceStockRequest reduceStockRequest = new ReduceStockRequest(orderQuantity);
             productClient.reduceStock(productId, reduceStockRequest);
         } catch (FeignException e) {
+            log.error("재고 감소 실패 - 상품 ID: {}", productId, e);
             throw new ProductException(ProductErrorCode.STOCK_UPDATE_FAILED);
         }
     }


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
- 마스터 관리자 권한으로 주문 생성 시, 배송 요청 되도록 feign client로 api 연결
- 주문 생성 시, 배송 경로 추가

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 배송 생성 요청 시 발생하던 역직렬화 문제 해결
- 📌 배송 생성 시, 도착 허브Id를 통해 배송지 자동 추가
- 📌 feign client 연결 된 api 예외 처리 추가
- 📌 주문 생성 시, 배송 경로 추가

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

- order.http의 기존 주문 생성 api 테스트에서 배송 정보 입력하여 테스트

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
