### PR TITLE
fix: Boolean isDeleted filed data type to boolean and apply @JsonProperty

### DIFF
--- a/service/company-app/src/main/java/io/fulflix/company/api/dto/CompanyDetailResponse.java
+++ b/service/company-app/src/main/java/io/fulflix/company/api/dto/CompanyDetailResponse.java
@@ -1,5 +1,6 @@
 package io.fulflix.company.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fulflix.company.domain.Company;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -13,7 +14,8 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class CompanyDetailResponse extends CompanyResponse {
 
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
     private LocalDateTime updatedAt;
     private Long updatedBy;
 

--- a/service/hub-app/src/main/java/io/fulflix/hub/hubroute/api/dto/HubRouteResponseDto.java
+++ b/service/hub-app/src/main/java/io/fulflix/hub/hubroute/api/dto/HubRouteResponseDto.java
@@ -1,5 +1,6 @@
 package io.fulflix.hub.hubroute.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fulflix.hub.hub.api.dto.HubResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,7 @@ public class HubRouteResponseDto {
     private Long duration;
     private Double distance;
     private String route;
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
 
 }

--- a/service/order-app/src/main/java/io/fulflix/infra/client/company/CompanyDetailResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/company/CompanyDetailResponse.java
@@ -1,9 +1,9 @@
 package io.fulflix.infra.client.company;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor
@@ -15,7 +15,8 @@ public class CompanyDetailResponse {
     private String companyName;
     private String companyType;
     private String companyAddress;
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
     private Long updatedBy;
     private LocalDateTime updatedAt;
 

--- a/service/order-app/src/main/java/io/fulflix/infra/client/product/ProductDetailResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/infra/client/product/ProductDetailResponse.java
@@ -1,9 +1,9 @@
 package io.fulflix.infra.client.product;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,7 +14,8 @@ public class ProductDetailResponse {
     private Long companyId;
     private String productName;
     private Integer stockQuantity;
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
     private Long updatedBy;
     private LocalDateTime updatedAt;
 

--- a/service/order-app/src/main/java/io/fulflix/order/api/dto/OrderDetailResponse.java
+++ b/service/order-app/src/main/java/io/fulflix/order/api/dto/OrderDetailResponse.java
@@ -1,5 +1,6 @@
 package io.fulflix.order.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fulflix.order.domain.Order;
 import io.fulflix.order.domain.OrderStatus;
 import java.time.LocalDateTime;
@@ -20,7 +21,8 @@ public class OrderDetailResponse {
     private Long productId;
     private Integer orderQuantity;
     private OrderStatus orderStatus;
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
     private LocalDateTime updatedAt;
     private Long updatedBy;
 

--- a/service/product-app/src/main/java/io/fulflix/infra/client/company/CompanyDetailResponse.java
+++ b/service/product-app/src/main/java/io/fulflix/infra/client/company/CompanyDetailResponse.java
@@ -1,6 +1,7 @@
 package io.fulflix.infra.client.company;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,8 @@ public class CompanyDetailResponse {
     private String companyName;
     private String companyType;
     private String companyAddress;
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
     private LocalDateTime updatedAt;
     private Long updatedBy;
 

--- a/service/product-app/src/main/java/io/fulflix/product/api/dto/ProductDetailResponse.java
+++ b/service/product-app/src/main/java/io/fulflix/product/api/dto/ProductDetailResponse.java
@@ -1,5 +1,6 @@
 package io.fulflix.product.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fulflix.product.domain.Product;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -13,7 +14,8 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class ProductDetailResponse extends ProductResponse {
 
-    private Boolean isDeleted;
+    @JsonProperty("isDeleted")
+    private boolean isDeleted;
     private LocalDateTime updatedAt;
     private Long updatedBy;
 


### PR DESCRIPTION
## ✏️ 작업한 내용을 간략히 설명해 주세요!
직렬화 시 ObjectMapper의 is 제거 네이밍 룰로 인해 isDeleted 필드의 타입 변경 부 원복 및 @JsonProperty 적용합니다.

## 🛠️ 변경을 위해 진행한 작업 내용에는 어떤 것이 있나요?

- 📌 Boolean isDeleted -> boolean isDeleted 원복
- 📌 boolean isDeleted 필드에 @JsonProperty("isDeleted") 적용

## 📝 변경 사항을 확인하기 위해 테스트한 방법을 설명해 주세요.

> 어떤 방법으로 테스트했는지 알려주세요.

## 💬 리뷰 요구사항

> 같이 논의했으면 하는 사항이 있으신가요?

## 📚 참고 자료

> 구현에 참고한 자료가 있다면 공유해주세요!

---
